### PR TITLE
Fix encoding of profile name

### DIFF
--- a/resources/lib/modules/authentication.py
+++ b/resources/lib/modules/authentication.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-from resources.lib.kodiwrapper import TitleItem
+from resources.lib.kodiwrapper import TitleItem, to_unicode
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import InvalidLoginException, LoginErrorException
 
@@ -89,7 +89,7 @@ class Authentication:
             '#FF0257': 'crimson',
         }
         if color_map.get(profile.color.upper()):
-            title = '[COLOR %s]%s[/COLOR]' % (color_map.get(profile.color), title)
+            title = '[COLOR %s]%s[/COLOR]' % (color_map.get(profile.color), to_unicode(title))
 
         # Append (Kids)
         if profile.product == 'VTM_GO_KIDS':

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -289,11 +289,21 @@ class VtmGo:
         response = self._get_url('/profiles', {'products': products})
         result = json.loads(response)
 
+        def _fix_wrong_encoding(str):
+            """ Fix encoding """
+            # VTM GO seems to return a wrongfully encoded name sometimes.
+            # This can be reproduced by giving a Profile a name with a special character.
+            # As soon as there is a kids profile with a special character, it works fine again.
+            try:
+                return str.encode('iso-8859-1')
+            except UnicodeEncodeError:
+                return str
+
         profiles = [
             Profile(
                 key=profile.get('id'),
                 product=profile.get('product'),
-                name=profile.get('name'),
+                name=_fix_wrong_encoding(profile.get('name')),
                 gender=profile.get('gender'),
                 birthdate=profile.get('birthDate'),
                 color=profile.get('color', {}).get('start'),

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -289,15 +289,15 @@ class VtmGo:
         response = self._get_url('/profiles', {'products': products})
         result = json.loads(response)
 
-        def _fix_wrong_encoding(str):
+        def _fix_wrong_encoding(value):
             """ Fix encoding """
             # VTM GO seems to return a wrongfully encoded name sometimes.
             # This can be reproduced by giving a Profile a name with a special character.
             # As soon as there is a kids profile with a special character, it works fine again.
             try:
-                return str.encode('iso-8859-1')
+                return value.encode('iso-8859-1')
             except UnicodeEncodeError:
-                return str
+                return value
 
         profiles = [
             Profile(


### PR DESCRIPTION
VTM GO seems to return the profiles with a wrong encoding when you have a special character, but if you have two profiles with a special character, they are returned fine.

This workaround fixes the issue by trying to decode it.