### PR TITLE
Add support for playing from the Guide with IPTV Manager

### DIFF
--- a/resources/lib/modules/iptvmanager.py
+++ b/resources/lib/modules/iptvmanager.py
@@ -62,6 +62,7 @@ class IPTVManager:
                 logo='special://home/addons/{addon}/resources/logos/{logo}.png'.format(addon=self._kodi.get_addon_id(), logo=channel.key)
                 if channel_data else channel.logo,
                 stream=self._kodi.url_for('play', category='channels', item=channel.channel_id),
+                vod=self._kodi.url_for('play_epg_datetime', channel=channel.key, timestamp='{date}'),
             ))
 
         return dict(version=1, streams=results)

--- a/resources/lib/vtmgo/vtmgoepg.py
+++ b/resources/lib/vtmgo/vtmgoepg.py
@@ -167,7 +167,7 @@ class VtmGoEpg:
         :rtype: EpgBroadcast
         """
         # Parse to a real datetime
-        timestamp = dateutil.parser.parse(timestamp)
+        timestamp = dateutil.parser.parse(timestamp).replace(tzinfo=dateutil.tz.gettz('CET'))
 
         # Load guide info for this date
         epg = self.get_epg(channel=channel, date=timestamp.strftime('%Y-%m-%d'))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -82,9 +82,8 @@ class TestRouting(unittest.TestCase):
         plugin.run([routing.url_for(plugin.play, category='episodes', item='ae0fa98d-6ed5-4f4a-8581-a051ed3bb755'), '0', ''])
 
     def test_play_epg(self):
-        import dateutil
         import datetime
-        timestamp = datetime.datetime.now(dateutil.tz.tzlocal()).replace(hour=6, minute=0, second=0)
+        timestamp = datetime.datetime.now().replace(hour=6, minute=0, second=0)
         plugin.run([routing.url_for(plugin.play_epg_datetime, channel='vtm', timestamp=timestamp.isoformat()), '0', ''])
 
     def test_metadata_update(self):


### PR DESCRIPTION
This PR adds support to play programs from the PVR Guide trough IPTV Manager.
It also fixes a bug that prevented the Add-on to play when the date had no timezone information.

This is the implementation for Leia.

Needs https://github.com/add-ons/service.iptv.manager/pull/19