### PR TITLE
Improve subtitle behaviour using PlayerMonitor

### DIFF
--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -344,7 +344,7 @@ class KodiWrapper:
     @staticmethod
     def get_setting(setting_id, default=None):
         """ Get an add-on setting """
-        value = to_unicode(ADDON.getSetting(setting_id))
+        value = to_unicode(xbmcaddon.Addon().getSetting(setting_id))
         if value == '' and default is not None:
             return default
         return value
@@ -606,103 +606,3 @@ class KodiWrapper:
             _LOGGER.error('Failed to send notification: %s', result.get('error').get('message'))
             return False
         return True
-
-
-class KodiPlayer(xbmc.Player):
-    """ A custom Player object to check if Playback has started """
-
-    def __init__(self, kodi=None):
-        """ Initialises a custom Player object
-        :type kodi: resources.lib.kodiwrapper.KodiWrapper
-        """
-        xbmc.Player.__init__(self)
-
-        self._kodi = kodi
-        self.__monitor = xbmc.Monitor()
-        self.__playBackEventsTriggered = False  # pylint: disable=invalid-name
-        self.__playPlayBackEndedEventsTriggered = False  # pylint: disable=invalid-name
-        self.__pollInterval = 1  # pylint: disable=invalid-name
-
-    def waitForPlayBack(self, url=None, time_out=30):  # pylint: disable=invalid-name
-        """ Blocks the call until playback is started. If an url was specified, it will wait
-        for that url to be the active one playing before returning.
-        :type url: str
-        :type time_out: int
-        """
-        _LOGGER.debug("Player: Waiting for playback")
-        if self.__is_url_playing(url):
-            self.__playBackEventsTriggered = True
-            _LOGGER.debug("Player: Already Playing")
-            return True
-
-        for i in range(0, int(time_out / self.__pollInterval)):
-            if self.__monitor.abortRequested():
-                _LOGGER.debug("Player: Abort requested (%s)" % i * self.__pollInterval)
-                return False
-
-            if self.__is_url_playing(url):
-                _LOGGER.debug("Player: PlayBack started (%s)" % i * self.__pollInterval)
-                return True
-
-            if self.__playPlayBackEndedEventsTriggered:
-                _LOGGER.warning("Player: PlayBackEnded triggered while waiting for start.")
-                return False
-
-            self.__monitor.waitForAbort(self.__pollInterval)
-            _LOGGER.debug("Player: Waiting for an abort (%s)", i * self.__pollInterval)
-
-        _LOGGER.warning("Player: time-out occurred waiting for playback (%s)", time_out)
-        return False
-
-    def onAVStarted(self):  # pylint: disable=invalid-name
-        """ Will be called when Kodi has a video or audiostream """
-        _LOGGER.debug("Player: [onAVStarted] called")
-        self.__playback_started()
-
-    def onPlayBackEnded(self):  # pylint: disable=invalid-name
-        """ Will be called when [Kodi] stops playing a file """
-        _LOGGER.debug("Player: [onPlayBackEnded] called")
-        self.__playback_stopped()
-
-    def onPlayBackStopped(self):  # pylint: disable=invalid-name
-        """ Will be called when [user] stops Kodi playing a file """
-        _LOGGER.debug("Player: [onPlayBackStopped] called")
-        self.__playback_stopped()
-
-    def onPlayBackError(self):  # pylint: disable=invalid-name
-        """ Will be called when playback stops due to an error. """
-        _LOGGER.debug("Player: [onPlayBackError] called")
-        self.__playback_stopped()
-
-    def __playback_stopped(self):
-        """ Sets the correct flags after playback stopped """
-        self.__playBackEventsTriggered = False
-        self.__playPlayBackEndedEventsTriggered = True
-
-    def __playback_started(self):
-        """ Sets the correct flags after playback started """
-        self.__playBackEventsTriggered = True
-        self.__playPlayBackEndedEventsTriggered = False
-
-    def __is_url_playing(self, url):
-        """ Checks whether the given url is playing
-        :param str url: The url to check for playback.
-        :return: Indication if the url is actively playing or not.
-        :rtype: bool
-        """
-        if not self.isPlaying():
-            _LOGGER.debug("Player: Not playing")
-            return False
-
-        if not self.__playBackEventsTriggered:
-            _LOGGER.debug("Player: Playing but the Kodi events did not yet trigger")
-            return False
-
-        # We are playing
-        if url is None or url.startswith("plugin://"):
-            _LOGGER.debug("Player: No valid URL to check playback against: %s", url)
-            return True
-
-        playing_file = self.getPlayingFile()
-        _LOGGER.debug("Player: Checking \n'%s' vs \n'%s'", url, playing_file)
-        return url == playing_file

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -606,3 +606,103 @@ class KodiWrapper:
             _LOGGER.error('Failed to send notification: %s', result.get('error').get('message'))
             return False
         return True
+
+
+class KodiPlayer(xbmc.Player):
+    """ A custom Player object to check if Playback has started """
+
+    def __init__(self, kodi=None):
+        """ Initialises a custom Player object
+        :type kodi: resources.lib.kodiwrapper.KodiWrapper
+        """
+        xbmc.Player.__init__(self)
+
+        self._kodi = kodi
+        self.__monitor = xbmc.Monitor()
+        self.__playBackEventsTriggered = False  # pylint: disable=invalid-name
+        self.__playPlayBackEndedEventsTriggered = False  # pylint: disable=invalid-name
+        self.__pollInterval = 1  # pylint: disable=invalid-name
+
+    def waitForPlayBack(self, url=None, time_out=30):  # pylint: disable=invalid-name
+        """ Blocks the call until playback is started. If an url was specified, it will wait
+        for that url to be the active one playing before returning.
+        :type url: str
+        :type time_out: int
+        """
+        _LOGGER.debug("Player: Waiting for playback")
+        if self.__is_url_playing(url):
+            self.__playBackEventsTriggered = True
+            _LOGGER.debug("Player: Already Playing")
+            return True
+
+        for i in range(0, int(time_out / self.__pollInterval)):
+            if self.__monitor.abortRequested():
+                _LOGGER.debug("Player: Abort requested (%s)" % i * self.__pollInterval)
+                return False
+
+            if self.__is_url_playing(url):
+                _LOGGER.debug("Player: PlayBack started (%s)" % i * self.__pollInterval)
+                return True
+
+            if self.__playPlayBackEndedEventsTriggered:
+                _LOGGER.warning("Player: PlayBackEnded triggered while waiting for start.")
+                return False
+
+            self.__monitor.waitForAbort(self.__pollInterval)
+            _LOGGER.debug("Player: Waiting for an abort (%s)", i * self.__pollInterval)
+
+        _LOGGER.warning("Player: time-out occurred waiting for playback (%s)", time_out)
+        return False
+
+    def onAVStarted(self):  # pylint: disable=invalid-name
+        """ Will be called when Kodi has a video or audiostream """
+        _LOGGER.debug("Player: [onAVStarted] called")
+        self.__playback_started()
+
+    def onPlayBackEnded(self):  # pylint: disable=invalid-name
+        """ Will be called when [Kodi] stops playing a file """
+        _LOGGER.debug("Player: [onPlayBackEnded] called")
+        self.__playback_stopped()
+
+    def onPlayBackStopped(self):  # pylint: disable=invalid-name
+        """ Will be called when [user] stops Kodi playing a file """
+        _LOGGER.debug("Player: [onPlayBackStopped] called")
+        self.__playback_stopped()
+
+    def onPlayBackError(self):  # pylint: disable=invalid-name
+        """ Will be called when playback stops due to an error. """
+        _LOGGER.debug("Player: [onPlayBackError] called")
+        self.__playback_stopped()
+
+    def __playback_stopped(self):
+        """ Sets the correct flags after playback stopped """
+        self.__playBackEventsTriggered = False
+        self.__playPlayBackEndedEventsTriggered = True
+
+    def __playback_started(self):
+        """ Sets the correct flags after playback started """
+        self.__playBackEventsTriggered = True
+        self.__playPlayBackEndedEventsTriggered = False
+
+    def __is_url_playing(self, url):
+        """ Checks whether the given url is playing
+        :param str url: The url to check for playback.
+        :return: Indication if the url is actively playing or not.
+        :rtype: bool
+        """
+        if not self.isPlaying():
+            _LOGGER.debug("Player: Not playing")
+            return False
+
+        if not self.__playBackEventsTriggered:
+            _LOGGER.debug("Player: Playing but the Kodi events did not yet trigger")
+            return False
+
+        # We are playing
+        if url is None or url.startswith("plugin://"):
+            _LOGGER.debug("Player: No valid URL to check playback against: %s", url)
+            return True
+
+        playing_file = self.getPlayingFile()
+        _LOGGER.debug("Player: Checking \n'%s' vs \n'%s'", url, playing_file)
+        return url == playing_file

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import logging
 
-from resources.lib.kodiwrapper import TitleItem
+from resources.lib.kodiwrapper import KodiPlayer, TitleItem, to_unicode
 from resources.lib.vtmgo.vtmgo import VtmGo, UnavailableException
 from resources.lib.vtmgo.vtmgostream import VtmGoStream, StreamGeoblockedException, StreamUnavailableException
 
@@ -80,6 +80,8 @@ class Player:
             'duration': resolved_stream.duration,
         }
 
+        upnext_data = None
+
         # Lookup metadata
         try:
             if category in ['movies', 'oneoffs']:
@@ -107,6 +109,13 @@ class Player:
                             'season': episode_details.season,
                             'episode': episode_details.number,
                         })
+
+                        # Lookup the next episode
+                        next_episode_details = self._vtm_go.get_next_episode_from_program(program, episode_details.season, episode_details.number)
+
+                        # Create the data for Up Next
+                        if next_episode_details:
+                            upnext_data = self.generate_upnext(episode_details, next_episode_details)
 
             elif category == 'channels':
                 info_dict.update({'mediatype': 'episode'})
@@ -140,6 +149,17 @@ class Player:
             ),
             license_key=self._vtm_go_stream.create_license_key(resolved_stream.license_url))
 
+        # Wait for playback to start
+        kodi_player = KodiPlayer(kodi=self._kodi)
+        if not kodi_player.waitForPlayBack(url=resolved_stream.url):
+            # Playback didn't start
+            return
+
+        # Send Up Next data
+        if upnext_data:
+            _LOGGER.debug("Sending Up Next data: %s", upnext_data)
+            self.send_upnext(upnext_data)
+
     def _check_credentials(self):
         """ Check if the user has credentials """
         if self._kodi.has_credentials():
@@ -170,3 +190,57 @@ class Player:
             return False
 
         return True
+
+    @staticmethod
+    def generate_upnext(current_episode, next_episode):
+        """ Construct the data for Up Next.
+        :type current_episode: resources.lib.vtmgo.vtmgo.Episode
+        :type next_episode: resources.lib.vtmgo.vtmgo.Episode
+        """
+        upnext_info = dict(
+            current_episode=dict(
+                episodeid=current_episode.episode_id,
+                tvshowid=current_episode.program_id,
+                title=current_episode.name,
+                art={
+                    'thumb': current_episode.cover,
+                },
+                season=current_episode.season,
+                episode=current_episode.number,
+                showtitle=current_episode.program_name,
+                plot=current_episode.description,
+                playcount=None,
+                rating=None,
+                firstaired=current_episode.aired[:10] if current_episode.aired else '',
+                runtime=current_episode.duration,
+            ),
+            next_episode=dict(
+                episodeid=next_episode.episode_id,
+                tvshowid=next_episode.program_id,
+                title=next_episode.name,
+                art={
+                    'thumb': next_episode.cover,
+                },
+                season=next_episode.season,
+                episode=next_episode.number,
+                showtitle=next_episode.program_name,
+                plot=next_episode.description,
+                playcount=None,
+                rating=None,
+                firstaired=next_episode.aired[:10] if next_episode.aired else '',
+                runtime=next_episode.duration,
+            ),
+            play_url='plugin://plugin.video.vtm.go/play/catalog/episodes/%s' % next_episode.episode_id,
+        )
+
+        return upnext_info
+
+    def send_upnext(self, upnext_info):
+        """ Send a message to Up Next with information about the next Episode.
+        :type upnext_info: object
+        """
+        from base64 import b64encode
+        from json import dumps
+        data = [to_unicode(b64encode(dumps(upnext_info).encode()))]
+        sender = '{addon_id}.SIGNAL'.format(addon_id='plugin.video.vtm.go')
+        self._kodi.notify(sender=sender, message='upnext_data', data=data)

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -6,12 +6,13 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 from time import time
 
-from xbmc import Monitor
+from xbmc import getInfoLabel, Monitor, Player
 
 from resources.lib import kodilogging
-from resources.lib.kodiwrapper import KodiWrapper
+from resources.lib.kodiwrapper import KodiWrapper, to_unicode
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
+from resources.lib.vtmgo.vtmgostream import VtmGoStream
 
 kodilogging.config()
 _LOGGER = logging.getLogger('service')
@@ -23,6 +24,7 @@ class BackgroundService(Monitor):
     def __init__(self):
         Monitor.__init__(self)
         self._kodi = KodiWrapper()
+        self._player = PlayerMonitor(kodi=self._kodi)
         self.vtm_go = VtmGo(self._kodi)
         self.vtm_go_auth = VtmGoAuth(self._kodi)
         self.update_interval = 24 * 3600  # Every 24 hours
@@ -72,6 +74,189 @@ class BackgroundService(Monitor):
         if success:
             self._kodi.set_setting('metadata_last_updated', str(int(time())))
 
+class PlayerMonitor(Player):
+    """ A custom Player object to check subtitles """
+
+    def __init__(self, kodi=None):
+        """ Initialises a custom Player object
+        :type kodi: resources.lib.kodiwrapper.KodiWrapper
+        """
+        self._kodi = kodi
+        self.__listen = False
+        self.__av_started = False
+        self.__path = None
+        self.__subtitle_path = None
+        Player.__init__(self)
+
+    def onPlayBackStarted(self):  # pylint: disable=invalid-name
+        """ Will be called when Kodi player starts """
+        self.__path = getInfoLabel('Player.FilenameAndPath')
+        if not self.__path.startswith('plugin://plugin.video.vtm.go/'):
+            self.__listen = False
+            return
+        self.__listen = True
+        _LOGGER.debug('Player: [onPlayBackStarted] called')
+        self.__subtitle_path = None
+        self.__av_started = False
+
+    def onAVStarted(self):  # pylint: disable=invalid-name
+        """ Will be called when Kodi has a video or audiostream """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onAVStarted] called')
+        self.__subtitle_path = self.__get_subtitle_path()
+        self.__av_started = True
+        self.__check_subtitles()
+
+    def onAVChange(self):  # pylint: disable=invalid-name
+        """ Will be called when Kodi has a video, audio or subtitle stream. Also happens when the stream changes """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onAVChange] called')
+        self.__check_subtitles()
+
+    def __check_subtitles(self):
+        """ Check subtitles """
+
+        # Check if subtitles are enabled before making any changes
+        response = self._kodi.jsonrpc(method='Player.GetProperties', params=dict(playerid=1, properties=['currentsubtitle', 'subtitleenabled', 'subtitles']))
+        subtitle_enabled = response.get('result').get('subtitleenabled')
+
+        # Make sure an internal InputStream Adaptive subtitle is selected, if available
+        available_subtitles = self.getAvailableSubtitleStreams()
+        if available_subtitles:
+            for i, subtitle in enumerate(available_subtitles):
+                if '(External)' not in subtitle and '(External)' in self.getSubtitles():
+                    self.setSubtitleStream(i)
+                    break
+        elif self.__av_started:
+            _LOGGER.debug('Player: No internal subtitles found')
+
+            # Add external subtitles
+            if self.__subtitle_path:
+                _LOGGER.debug('Player: Adding external subtitles %s', self.__subtitle_path)
+                self.setSubtitles(self.__subtitle_path)
+
+        # Enable subtitles if needed
+        show_subtitles = self._kodi.get_setting_as_bool('showsubtitles')
+        if show_subtitles and not subtitle_enabled:
+            _LOGGER.debug('Player: Enabling subtitles')
+            self.showSubtitles(True)
+        elif not subtitle_enabled:
+            _LOGGER.debug('Player: Disabling subtitles')
+            self.showSubtitles(False)
+
+    def onPlayBackSeek(self, seekTime, seekOffset):  # pylint: disable=invalid-name, unused-argument
+        """ Will be called when user seeks to a time """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onPlayBackSeek] called')
+
+    def onPlayBackEnded(self):  # pylint: disable=invalid-name
+        """ Will be called when [Kodi] stops playing a file """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onPlayBackEnded] called')
+        self.__av_started = False
+        self.__subtitle_path = None
+
+    def onPlayBackStopped(self):  # pylint: disable=invalid-name
+        """ Will be called when [user] stops Kodi playing a file """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onPlayBackStopped] called')
+        self.__av_started = False
+        self.__subtitle_path = None
+
+    def onPlayBackError(self):  # pylint: disable=invalid-name
+        """ Will be called when playback stops due to an error. """
+        if not self.__listen:
+            return
+        _LOGGER.debug('Player: [onPlayBackError] called')
+        self.__av_started = False
+        self.__subtitle_path = None
+
+    def __get_subtitle_path(self):
+        """ Get the external subtitles path """
+        temp_path = self._kodi.get_userdata_path() + 'temp/'
+        files = None
+        if self._kodi.check_if_path_exists(temp_path):
+            _, files = self._kodi.listdir(temp_path)
+        if files and len(files) == 1:
+            return temp_path + files[0]
+        _LOGGER.debug('Player: No subtitle path')
+        return None
+
+
+    def __send_upnext(self, episode_id, season, episode):
+        """ Send a message to Up Next with information about the next Episode.
+        :type string: episode_id
+        :type season: int
+        :type episode: int
+        """
+        from base64 import b64encode
+        from json import dumps
+
+        # Get episode details from episode_id
+        program_id = self._vtm_go_stream.get_stream('episodes', episode_id).program_id
+        program = self._vtm_go.get_program(program_id)
+        episode_details = self._vtm_go.get_episode_from_program(program, episode_id)
+
+        # Lookup the next episode
+        next_episode_details = self._vtm_go.get_next_episode_from_program(program, season, episode)
+
+        # Create the info for Up Next
+        if next_episode_details:
+            upnext_info = self.__generate_upnext(episode_details, next_episode_details)
+
+        data = [to_unicode(b64encode(dumps(upnext_info).encode()))]
+        sender = '{addon_id}.SIGNAL'.format(addon_id='plugin.video.vtm.go')
+        _LOGGER.debug('Sending Up Next data: %s', upnext_info)
+        self._kodi.notify(sender=sender, message='upnext_data', data=data)
+
+    @staticmethod
+    def __generate_upnext(current_episode, next_episode):
+        """ Construct the data for Up Next.
+        :type current_episode: resources.lib.vtmgo.vtmgo.Episode
+        :type next_episode: resources.lib.vtmgo.vtmgo.Episode
+        """
+        upnext_info = dict(
+            current_episode=dict(
+                episodeid=current_episode.episode_id,
+                tvshowid=current_episode.program_id,
+                title=current_episode.name,
+                art={
+                    'thumb': current_episode.cover,
+                },
+                season=current_episode.season,
+                episode=current_episode.number,
+                showtitle=current_episode.program_name,
+                plot=current_episode.description,
+                playcount=None,
+                rating=None,
+                firstaired=current_episode.aired[:10] if current_episode.aired else '',
+                runtime=current_episode.duration,
+            ),
+            next_episode=dict(
+                episodeid=next_episode.episode_id,
+                tvshowid=next_episode.program_id,
+                title=next_episode.name,
+                art={
+                    'thumb': next_episode.cover,
+                },
+                season=next_episode.season,
+                episode=next_episode.number,
+                showtitle=next_episode.program_name,
+                plot=next_episode.description,
+                playcount=None,
+                rating=None,
+                firstaired=next_episode.aired[:10] if next_episode.aired else '',
+                runtime=next_episode.duration,
+            ),
+            play_url='plugin://plugin.video.vtm.go/play/catalog/episodes/%s' % next_episode.episode_id,
+        )
+
+        return upnext_info
 
 def run():
     """ Run the BackgroundService """

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -9,6 +9,7 @@ import logging
 import requests
 
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
+from resources.lib.vtmgo.vtmgostream import VtmGoStream
 
 _LOGGER = logging.getLogger('vtmgo')
 
@@ -277,6 +278,7 @@ class VtmGo:
         self._kodi = kodi
         self._proxies = kodi.get_proxies()
         self._auth = VtmGoAuth(kodi)
+        self._stream = VtmGoStream(kodi)
 
     def _mode(self):
         """ Return the mode that should be used for API calls """

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -9,7 +9,6 @@ import logging
 import requests
 
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
-from resources.lib.vtmgo.vtmgostream import VtmGoStream
 
 _LOGGER = logging.getLogger('vtmgo')
 
@@ -278,7 +277,6 @@ class VtmGo:
         self._kodi = kodi
         self._proxies = kodi.get_proxies()
         self._auth = VtmGoAuth(kodi)
-        self._stream = VtmGoStream(kodi)
 
     def _mode(self):
         """ Return the mode that should be used for API calls """

--- a/tests/xbmc.py
+++ b/tests/xbmc.py
@@ -114,6 +114,10 @@ class Player:
         """ A stub implementation for the xbmc Player class setSubtitles() method """
         return
 
+    def setSubtitleStream(self, iStream):
+        """ A stub implementation for the xbmc Player class setSubtitleStream() method """
+        return
+
     def showSubtitles(self, visible):
         """ A stub implementation for the xbmc Player class showSubtitles() method """
         return
@@ -132,6 +136,14 @@ class Player:
 
     def getPlayingFile(self):
         """ A stub implementation for the xbmc Player class getPlayingFile() method """
+        return ''
+
+    def getAvailableSubtitleStreams(self):
+        """ A stub implementation for the xbmc Player class getAvailableSubtitleStreams() method """
+        return []
+
+    def getSubtitles(self):
+        """ A stub implementation for the xbmc Player class getSubtitles() method """
         return ''
 
 


### PR DESCRIPTION
This includes:
- Implement PlayerMonitor service
- Check subtitles `onAVStarted` and `onAVChange`:
  - Select internal InputStream Adaptive subtitles if available
  - Add external recalculated subtitle if no subtitles available
  - Enable subtitles if `showsubtitles` add-on setting is enabled

There are still bugs in InputStream Adaptive or Kodi that cause the following problems:
- ~Internal subtitles suddenly disappear, seeking fixes this~ fixed in https://github.com/peak3d/inputstream.adaptive/pull/456
- External subtitles get out of sync when a new period starts