### PR TITLE
Support new inputstream api in Kodi 19

### DIFF
--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -206,7 +206,10 @@ class KodiWrapper:
         :type license_key: string
         """
         play_item = self._generate_listitem(title_item)
-        play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        if self.kodi_version_major() < 19:
+            play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        else:
+            play_item.setProperty('inputstream', 'inputstream.adaptive')
         play_item.setProperty('inputstream.adaptive.max_bandwidth', str(self.get_max_bandwidth() * 1000))
         play_item.setProperty('network.bandwidth', str(self.get_max_bandwidth() * 1000))
         play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')


### PR DESCRIPTION
Since https://github.com/xbmc/xbmc/pull/18002 has been merged, the VTM GO add-on can no longer play video with InputStream Adaptive with Kodi 19 master branch. This PR fixes this.

A Kodi 19 nightly build that includes this breaking api change will be released in the coming days.