### PR TITLE
Fix data transfers over 1 MB to IPTV Manager

### DIFF
--- a/resources/lib/modules/iptvmanager.py
+++ b/resources/lib/modules/iptvmanager.py
@@ -35,7 +35,7 @@ class IPTVManager:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('127.0.0.1', self.port))
             try:
-                sock.send(json.dumps(func(self)).encode())  # pylint: disable=not-callable
+                sock.sendall(json.dumps(func(self)).encode())  # pylint: disable=not-callable
             finally:
                 sock.close()
 


### PR DESCRIPTION
This fixes the transfer of data over 1 MB over the socket. It seems that on some systems, `sock.send` doesn't send the full string. This is intended documented behaviour, `sock.sendall` should be used for this.