### PR TITLE
Make authentication more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@
 Thumbs.db
 *~
 .cache
-
 .coverage
 .tox/
+
+# Testing
 tests/home/userdata/addon_data
+.env

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -118,8 +118,7 @@ class Movie:
     """ Defines a Movie """
 
     def __init__(self, movie_id=None, name=None, description=None, year=None, cover=None, image=None, duration=None,
-                 remaining=None, geoblocked=None,
-                 channel=None, legal=None, aired=None, my_list=None):
+                 remaining=None, geoblocked=None, channel=None, legal=None, aired=None, my_list=None):
         """
         :type movie_id: str
         :type name: str
@@ -157,8 +156,7 @@ class Program:
     """ Defines a Program """
 
     def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
-                 geoblocked=None, channel=None, legal=None,
-                 my_list=None):
+                 geoblocked=None, channel=None, legal=None, my_list=None):
         """
         :type program_id: str
         :type name: str
@@ -213,9 +211,8 @@ class Episode:
     """ Defines an Episode """
 
     def __init__(self, episode_id=None, program_id=None, program_name=None, number=None, season=None, name=None,
-                 description=None, cover=None, duration=None,
-                 remaining=None, geoblocked=None, channel=None, legal=None, aired=None, progress=None, watched=False,
-                 next_episode=None):
+                 description=None, cover=None, duration=None, remaining=None, geoblocked=None, channel=None, legal=None,
+                 aired=None, progress=None, watched=False, next_episode=None):
         """
         :type episode_id: str
         :type program_id: str
@@ -629,8 +626,8 @@ class VtmGo:
             seasons[item_season.get('index')] = Season(
                 number=item_season.get('index'),
                 episodes=episodes,
-                cover=item_season.get('episodes', [{}])[0].get('bigPhotoUrl') if episodes else program.get(
-                    'bigPhotoUrl'),
+                cover=item_season.get('episodes', [{}])[0].get('bigPhotoUrl')
+                if episodes else program.get('bigPhotoUrl'),
                 geoblocked=program.get('geoBlocked'),
                 channel=channel,
                 legal=program.get('legalIcons'),

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -795,15 +795,15 @@ class VtmGo:
             # Retry the same request
             return self._request('PUT', url, params=params)
 
-    def _post_url(self, url, params=None, json=None):
+    def _post_url(self, url, params=None, data=None):
         """ Makes a POST request for the specified URL.
         :type url: str
         :type params: dict
-        :type json: dict
+        :type data: dict
         :rtype str
         """
         try:
-            return self._request('POST', url, params=params, json=json)
+            return self._request('POST', url, params=params, data=data)
         except InvalidLoginException:
             self._auth.clear_token()
             self._authenticate()
@@ -824,18 +824,18 @@ class VtmGo:
             # Retry the same request
             return self._request('DELETE', url, params=params)
 
-    def _request(self, method, url, params=None, json=None):
+    def _request(self, method, url, params=None, data=None):
         """ Makes a request for the specified URL.
         :type url: str
         :type params: dict
-        :type json: dict
+        :type data: dict
         :rtype str
         """
         _LOGGER.debug('Sending %s %s...', method, url)
         response = self._session.request(method,
                                          self.API_ENDPOINT + url,
                                          params=params,
-                                         json=json)
+                                         json=data)
 
         # Set encoding to UTF-8 if no charset is indicated in http headers (https://github.com/psf/requests/issues/1604)
         if not response.encoding:

--- a/resources/lib/vtmgo/vtmgoauth.py
+++ b/resources/lib/vtmgo/vtmgoauth.py
@@ -91,7 +91,7 @@ class VtmGoAuth:
 
         # Make sure the path exists
         if not self._kodi.check_if_path_exists(userdata_path):
-            self._kodi.mkdir(userdata_path)
+            self._kodi.mkdirs(userdata_path)
 
         with self._kodi.open_file(path, 'w') as fdesc:
             fdesc.write(from_unicode(self._token))

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -266,7 +266,7 @@ class VtmGoStream:
 
         import re
         if not self._kodi.check_if_path_exists(temp_dir):
-            self._kodi.mkdir(temp_dir)
+            self._kodi.mkdirs(temp_dir)
 
         ad_breaks = list()
         delayed_subtitles = list()


### PR DESCRIPTION
* Retry request with a new token when authentication has failed. It seems the tokens are valid for a long time, but there was no code to handle the case when it would finally be invalid. It might happen after a year, not sure. The actual JWT is only valid for one day, but it seems expired JWT tokens are still accepted by VTM GO.
* Reuse `request.session` object
* Make sure the path exists to store the token
* Small cleanups