### PR TITLE
Fix paths in Windows

### DIFF
--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -110,7 +110,7 @@ class KodiWrapper:
             self._url = None
         self._addon_name = ADDON.getAddonInfo('name')
         self._addon_id = ADDON.getAddonInfo('id')
-        self._cache_path = os.path.join(self.get_userdata_path(), 'cache')
+        self._cache_path = os.path.join(self.get_userdata_path(), 'cache', '')
 
     def url_for(self, name, *args, **kwargs):
         """ Wrapper for routing.url_for() to lookup by name """
@@ -526,9 +526,10 @@ class KodiWrapper:
 
     @staticmethod
     def listdir(path):
-        """ Return all files in a directory (using xbmcvfs)"""
-        from xbmcvfs import listdir
-        return listdir(path)
+        """Return all files in a directory (using xbmcvfs)"""
+        from xbmcvfs import listdir as vfslistdir
+        dirs, files = vfslistdir(from_unicode(path))
+        return [to_unicode(item) for item in dirs], [to_unicode(item) for item in files]
 
     @staticmethod
     def mkdir(path):

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -253,7 +253,7 @@ class VtmGoStream:
         :rtype list[str]
         """
         # Clean up old subtitles
-        temp_dir = os.path.join(self._kodi.get_userdata_path(), 'temp')
+        temp_dir = os.path.join(self._kodi.get_userdata_path(), 'temp', '')
         _, files = self._kodi.listdir(temp_dir)
         if files:
             for item in files:
@@ -280,7 +280,7 @@ class VtmGoStream:
             )
 
         for subtitle in subtitles:
-            output_file = temp_dir + '/' + subtitle.get('name') + '.' + subtitle.get('url').split('.')[-1]
+            output_file = temp_dir + subtitle.get('name') + '.' + subtitle.get('url').split('.')[-1]
             webvtt_content = requests.get(subtitle.get('url')).text
             webvtt_content = webvtt_timing_regex.sub(lambda match: self._delay_webvtt_timing(match, ad_breaks), webvtt_content)
             with self._kodi.open_file(output_file, 'w') as webvtt_output:


### PR DESCRIPTION
This should fix unicode problems with windows paths (https://github.com/add-ons/plugin.video.vtm.go/issues/196), should be tested on other platforms like LibreELEC on RPi or other cheap Linux devices.