### PR TITLE
Fix credentials and profile not properly saved

### DIFF
--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -7,8 +7,9 @@ import logging
 from time import time
 
 from xbmc import getInfoLabel, Monitor, Player
+from xbmcaddon import Addon
 
-from resources.lib import kodilogging
+from resources.lib import kodilogging, kodiwrapper
 from resources.lib.kodiwrapper import KodiWrapper
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
@@ -47,6 +48,7 @@ class BackgroundService(Monitor):
     def onSettingsChanged(self):  # pylint: disable=invalid-name
         """ Callback when a setting has changed """
         # Refresh our VtmGo instance
+        kodiwrapper.ADDON = Addon()
         self.vtm_go = VtmGo(self._kodi)
 
         if self.vtm_go_auth.has_credentials_changed():

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -289,9 +289,13 @@ class VtmGo:
         if token:
             self._session.headers['x-dpp-jwt'] = token
 
-        profile = self._auth.get_profile()
-        if profile:
-            self._session.headers['x-dpp-profile'] = profile
+            profile = self._auth.get_profile()
+            if profile:
+                self._session.headers['x-dpp-profile'] = profile
+            else:
+                # Select default profile
+                default_profile = self.get_profiles()[0]
+                self._session.headers['x-dpp-profile'] = default_profile.key
 
     def _mode(self):
         """ Return the mode that should be used for API calls """


### PR DESCRIPTION
There was an issue when the Addon was started fresh, and an item was played without going to settings first to enter your credentials, it would not correctly save the credentials, putting the Add-on into a "bad" state where you would need to enter the credentials every time.

I believe this fixes that issue.

Fixes #195 