### PR TITLE
Use a uuid as a cookie for the EPG

### DIFF
--- a/resources/lib/vtmgo/vtmgoepg.py
+++ b/resources/lib/vtmgo/vtmgoepg.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 import json
 import logging
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 import dateutil.parser
 import dateutil.tz
@@ -91,7 +92,7 @@ class VtmGoEpg:
         self._kodi = kodi
 
         self._session = requests.session()
-        self._session.cookies.set('authId', '')
+        self._session.cookies.set('authId', str(uuid4()))
 
     def get_epg(self, channel, date=None):
         """ Load EPG information for the specified channel and date.


### PR DESCRIPTION
Followup of #210 by @mediaminister 

So it seems that the `authId` isn't validated, but I thought it would be a good idea to actually send an uuid instead of an empty string. An empty string is easily checked, but an actual uuid can only be validated by checking the privacy-gate.

