### PR TITLE
Fix for upcoming UpNext release

### DIFF
--- a/resources/lib/kodiplayer.py
+++ b/resources/lib/kodiplayer.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""Custom Kodi Player"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+
+import xbmc
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class KodiPlayer(xbmc.Player):
+    """ A custom Player object to check if Playback has started """
+
+    def __init__(self):
+        """ Initialises a custom Player object
+        """
+        xbmc.Player.__init__(self)
+
+        self.__monitor = xbmc.Monitor()
+        self.__playBackEventsTriggered = False  # pylint: disable=invalid-name
+        self.__playPlayBackStoppedEventsTriggered = False  # pylint: disable=invalid-name
+        self.__pollInterval = 1  # pylint: disable=invalid-name
+
+    def waitForPlayBack(self, url=None, time_out=30):  # pylint: disable=invalid-name
+        """ Blocks the call until playback is started. If an url was specified, it will wait
+        for that url to be the active one playing before returning.
+        :type url: str
+        :type time_out: int
+        """
+        _LOGGER.debug("Player: Waiting for playback")
+        if self.__is_url_playing(url):
+            self.__playBackEventsTriggered = True
+            _LOGGER.debug("Player: Already Playing")
+            return True
+
+        for i in range(0, int(time_out / self.__pollInterval)):
+            if self.__monitor.abortRequested():
+                _LOGGER.debug("Player: Abort requested (%s)" % i * self.__pollInterval)
+                return False
+
+            if self.__is_url_playing(url):
+                _LOGGER.debug("Player: PlayBack started (%s)" % i * self.__pollInterval)
+                return True
+
+            if self.__playPlayBackStoppedEventsTriggered:
+                _LOGGER.warning("Player: PlayBackStopped triggered while waiting for start.")
+                return False
+
+            self.__monitor.waitForAbort(self.__pollInterval)
+            _LOGGER.debug("Player: Waiting for an abort (%s)", i * self.__pollInterval)
+
+        _LOGGER.warning("Player: time-out occurred waiting for playback (%s)", time_out)
+        return False
+
+    def onAVStarted(self):  # pylint: disable=invalid-name
+        """ Will be called when Kodi has a video or audiostream """
+        _LOGGER.debug("Player: [onAVStarted] called")
+        self.__playback_started()
+
+    def onPlayBackStopped(self):  # pylint: disable=invalid-name
+        """ Will be called when [user] stops Kodi playing a file """
+        _LOGGER.debug("Player: [onPlayBackStopped] called")
+        self.__playback_stopped()
+
+    def onPlayBackError(self):  # pylint: disable=invalid-name
+        """ Will be called when playback stops due to an error. """
+        _LOGGER.debug("Player: [onPlayBackError] called")
+        self.__playback_stopped()
+
+    def __playback_stopped(self):
+        """ Sets the correct flags after playback stopped """
+        self.__playBackEventsTriggered = False
+        self.__playPlayBackStoppedEventsTriggered = True
+
+    def __playback_started(self):
+        """ Sets the correct flags after playback started """
+        self.__playBackEventsTriggered = True
+        self.__playPlayBackStoppedEventsTriggered = False
+
+    def __is_url_playing(self, url):
+        """ Checks whether the given url is playing
+        :param str url: The url to check for playback.
+        :return: Indication if the url is actively playing or not.
+        :rtype: bool
+        """
+        if not self.isPlaying():
+            _LOGGER.debug("Player: Not playing")
+            return False
+
+        if not self.__playBackEventsTriggered:
+            _LOGGER.debug("Player: Playing but the Kodi events did not yet trigger")
+            return False
+
+        # We are playing
+        if url is None or url.startswith("plugin://"):
+            _LOGGER.debug("Player: No valid URL to check playback against: %s", url)
+            return True
+
+        playing_file = self.getPlayingFile()
+        _LOGGER.debug("Player: Checking \n'%s' vs \n'%s'", url, playing_file)
+        return url == playing_file

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -2,9 +2,10 @@
 """All functionality that requires Kodi imports"""
 
 from __future__ import absolute_import, division, unicode_literals
-from contextlib import contextmanager
+
 import logging
 import os
+from contextlib import contextmanager
 
 import xbmc
 import xbmcaddon
@@ -701,100 +702,3 @@ def notify(sender, message, data):
         return False
     _LOGGER.debug('Succesfully sent notification')
     return True
-
-
-class KodiPlayer(xbmc.Player):
-    """ A custom Player object to check if Playback has started """
-
-    def __init__(self):
-        """ Initialises a custom Player object """
-        xbmc.Player.__init__(self)
-
-        self.__monitor = xbmc.Monitor()
-        self.__playBackEventsTriggered = False  # pylint: disable=invalid-name
-        self.__playPlayBackEndedEventsTriggered = False  # pylint: disable=invalid-name
-        self.__pollInterval = 1  # pylint: disable=invalid-name
-
-    def waitForPlayBack(self, url=None, time_out=30):  # pylint: disable=invalid-name
-        """ Blocks the call until playback is started. If an url was specified, it will wait
-        for that url to be the active one playing before returning.
-        :type url: str
-        :type time_out: int
-        """
-        _LOGGER.debug("Player: Waiting for playback")
-        if self.__is_url_playing(url):
-            self.__playBackEventsTriggered = True
-            _LOGGER.debug("Player: Already Playing")
-            return True
-
-        for i in range(0, int(time_out / self.__pollInterval)):
-            if self.__monitor.abortRequested():
-                _LOGGER.debug("Player: Abort requested (%s)" % i * self.__pollInterval)
-                return False
-
-            if self.__is_url_playing(url):
-                _LOGGER.debug("Player: PlayBack started (%s)" % i * self.__pollInterval)
-                return True
-
-            if self.__playPlayBackEndedEventsTriggered:
-                _LOGGER.warning("Player: PlayBackEnded triggered while waiting for start.")
-                return False
-
-            self.__monitor.waitForAbort(self.__pollInterval)
-            _LOGGER.debug("Player: Waiting for an abort (%s)", i * self.__pollInterval)
-
-        _LOGGER.warning("Player: time-out occurred waiting for playback (%s)", time_out)
-        return False
-
-    def onAVStarted(self):  # pylint: disable=invalid-name
-        """ Will be called when Kodi has a video or audiostream """
-        _LOGGER.debug("Player: [onAVStarted] called")
-        self.__playback_started()
-
-    def onPlayBackEnded(self):  # pylint: disable=invalid-name
-        """ Will be called when [Kodi] stops playing a file """
-        _LOGGER.debug("Player: [onPlayBackEnded] called")
-        self.__playback_stopped()
-
-    def onPlayBackStopped(self):  # pylint: disable=invalid-name
-        """ Will be called when [user] stops Kodi playing a file """
-        _LOGGER.debug("Player: [onPlayBackStopped] called")
-        self.__playback_stopped()
-
-    def onPlayBackError(self):  # pylint: disable=invalid-name
-        """ Will be called when playback stops due to an error. """
-        _LOGGER.debug("Player: [onPlayBackError] called")
-        self.__playback_stopped()
-
-    def __playback_stopped(self):
-        """ Sets the correct flags after playback stopped """
-        self.__playBackEventsTriggered = False
-        self.__playPlayBackEndedEventsTriggered = True
-
-    def __playback_started(self):
-        """ Sets the correct flags after playback started """
-        self.__playBackEventsTriggered = True
-        self.__playPlayBackEndedEventsTriggered = False
-
-    def __is_url_playing(self, url):
-        """ Checks whether the given url is playing
-        :param str url: The url to check for playback.
-        :return: Indication if the url is actively playing or not.
-        :rtype: bool
-        """
-        if not self.isPlaying():
-            _LOGGER.debug("Player: Not playing")
-            return False
-
-        if not self.__playBackEventsTriggered:
-            _LOGGER.debug("Player: Playing but the Kodi events did not yet trigger")
-            return False
-
-        # We are playing
-        if url is None or url.startswith("plugin://"):
-            _LOGGER.debug("Player: No valid URL to check playback against: %s", url)
-            return True
-
-        playing_file = self.getPlayingFile()
-        _LOGGER.debug("Player: Checking \n'%s' vs \n'%s'", url, playing_file)
-        return url == playing_file

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 
 from resources.lib import kodiutils
+from resources.lib.kodiplayer import KodiPlayer
 from resources.lib.vtmgo.vtmgo import VtmGo, UnavailableException
-from resources.lib.vtmgo.vtmgostream import VtmGoStream, StreamGeoblockedException, StreamUnavailableException
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
+from resources.lib.vtmgo.vtmgostream import VtmGoStream, StreamGeoblockedException, StreamUnavailableException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class Player:
         kodiutils.play(resolved_stream.url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict)
 
         # Wait for playback to start
-        kodi_player = kodiutils.KodiPlayer()
+        kodi_player = KodiPlayer()
         if not kodi_player.waitForPlayBack(url=resolved_stream.url):
             # Playback didn't start
             return


### PR DESCRIPTION
* Splitted the KodiPlayer into a seperate class, like we did in the streamz addon.
* Don't listen for onPlayBackEnded events when waiting to send UpNext data.

The next UpNext version will start the following episodes with a playlist, and it seems Kodi doesn't actually stop the VideoPlayer until the next episode starts (this actually looks quite nice, since it doesn't fallback to the episode overview anymore). This needs a small change in the way we wait to send the UpNext data. We still listen to onPlaybackStopped and onPlaybackError events. These are emitted when the user invokes stop himself, or when an error occurs.

@dagwieers 