### PR TITLE
Use previous sakee version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ python-dateutil
 requests
 git+git://github.com/dagwieers/kodi-plugin-routing.git@setup#egg=routing
 tox
-sakee
+sakee==0.0.7


### PR DESCRIPTION
There is a bug in the new sakee 0.0.8 version, released 4 days ago:
```

2020-10-21T05:40:54.9852882Z   File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/site-packages/sakee/stub.py", line 24, in get_next_input
2020-10-21T05:40:54.9853458Z     return self.__queue.pop(0)
2020-10-21T05:40:54.9853809Z IndexError: pop from empty list
```

Using sakee 0.0.7 for now is better.