### PR TITLE
Fix unicode in search

### DIFF
--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -382,7 +382,8 @@ class VtmGo:
         :type search: str
         :rtype list[Union[Movie, Program]]
         """
-        response = util.http_get(API_ENDPOINT + '/%s/search/?query=%s' % (self._mode(), quote(search)),
+        response = util.http_get(API_ENDPOINT + '/%s/search/?query=%s' % (self._mode(),
+                                                                          kodiutils.to_unicode(quote(kodiutils.from_unicode(search)))),
                                  token=self._tokens.jwt_token,
                                  profile=self._tokens.profile)
         results = json.loads(response.text)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -75,6 +75,7 @@ class TestRouting(unittest.TestCase):
     def test_search_menu(self):
         addon.run([routing.url_for(addon.show_search), '0', ''])
         addon.run([routing.url_for(addon.show_search, query='nieuws'), '0', ''])
+        addon.run([routing.url_for(addon.show_search, query='Loïc'), '0', ''])
 
     def test_tvguide_menu(self):
         addon.run([routing.url_for(addon.show_tvguide_channel, channel='vtm'), '0', ''])


### PR DESCRIPTION
This fixes search strings with special chars. For instance:
- Loïc (cooking show)
- Amélie (soap character)