### PR TITLE
Allow to install and run Kodi Logfile Uploader from the settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -450,3 +450,11 @@ msgstr ""
 msgctxt "#30891"
 msgid "Enable debug logging"
 msgstr ""
+
+msgctxt "#30892"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30893"
+msgid "Open Kodi Logfile Uploader…"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -451,3 +451,11 @@ msgstr "Logboek"
 msgctxt "#30891"
 msgid "Enable debug logging"
 msgstr "Activeer debug logging"
+
+msgctxt "#30892"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30893"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -46,5 +46,7 @@
         <setting label="30887" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)"/>
         <setting label="30889" type="lsep"/> <!-- Logging -->
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
+        <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30893" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
     </category>
 </settings>


### PR DESCRIPTION
This adds an item to the Expert settings to allow users to view or upload their kodi log using the **Kodi Logfile Uploader** Add-on. This makes it easier to troubleshoot issues on systems where the log is difficult to access, like the new Google Chromecast (Android TV).

It seems that on LibreElec this feature is already integrated in the LibreElec settings.