### PR TITLE
Integrate Movies and TV Series into the Kodi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Contributors](https://img.shields.io/github/contributors/add-ons/plugin.video.vtm.go.svg)](https://github.com/add-ons/plugin.video.vtm.go/graphs/contributors)
 
-# VTM GO Kodi add-on
+# VTM GO Kodi Add-on
 
 *plugin.video.vtm.go* is a Kodi add-on for watching live video streams and video-on-demand content available on the VTM GO platform. 
 
@@ -33,6 +33,35 @@ The following features are supported:
 * Search the catalogue
 * Watch YouTube content from some of the DPG Media channels
 * Integration with [IPTV Manager](https://github.com/add-ons/service.iptv.manager)
+* Integratie met Kodi bibliotheek
+
+## Integratie met Kodi
+
+Je kan deze Add-on gebruiken als medialocatie in Kodi zodat de films en series ook in je Kodi bibliotheek geindexeerd staan. Ze worden uiteraard nog steeds
+gewoon gestreamed.
+
+Ga hiervoor naar **Instellingen** > **Media** > **Bibliotheek** > **Video's...** (bij bronnen beheren). Kies vervolgens **Toevoegen video's...** en geef
+onderstaande locatie in door **< Geen >** te kiezen. Geef vervolgens de naam op en kies OK. Stel daarna de opties in zoals hieronder opgegeven en bevestig met OK.
+Stem daarna toe om deze locaties te scannen.
+
+* Films:
+  * Locatie: `plugin://plugin.video.vtm.go/library/movies/`
+  * Naam: **VTM GO - Films**
+  * Opties:
+    * Deze map bevat: **Speelfilms**
+    * Kies informatieleverancier: **Local information only**
+    * Films staan in aparte folders die overeenkomen met de filmtitel: **Uit**
+    * Ook onderliggende mappen scannen : **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
+
+* Series:
+  * Locatie: `plugin://plugin.video.vtm.go/library/tvshows/`
+  * Naam: **VTM GO - Series**
+  * Opties:
+    * Deze map bevat: **Series**
+    * Kies informatieleverancier: **Local information only**
+    * Geselecteerde map bevat één enkele serie: **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
 
 ## Screenshots
 

--- a/addon.xml
+++ b/addon.xml
@@ -12,6 +12,8 @@
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
+        <medialibraryscanpath content="movies">library/movies/</medialibraryscanpath>
+        <medialibraryscanpath content="tvshows">library/tvshows/</medialibraryscanpath>
     </extension>
     <extension point="xbmc.service" library="service_entry.py"/>
     <extension point="xbmc.addon.metadata">

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -423,6 +423,46 @@ msgctxt "#30869"
 msgid "IPTV Manager settings…"
 msgstr ""
 
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr ""
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr ""
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr ""
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr ""
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr ""
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr ""
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr ""
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr ""
+
+msgctxt "#30879"
+msgid "Clean Library…"
+msgstr ""
+
 msgctxt "#30880"
 msgid "Expert"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -424,6 +424,46 @@ msgctxt "#30869"
 msgid "IPTV Manager settings…"
 msgstr "IPTV Manager instellingen…"
 
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr "Kodi-bibliotheek"
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr "Indexeren"
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr "Videolocaties toevoegen aan de Kodi-bibliotheek… [COLOR gray](Zie README.md)[/COLOR]"
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr "Indexeer de volgende films"
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr "Indexeer de volgende series"
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr "Volledige catalogus"
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr "Enkel items op 'Mijn lijst'"
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr "Onderhoud"
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr "Verniew bibliotheek…"
+
+msgctxt "#30879"
+msgid "Clean Library…"
+msgstr "Bibliotheek opkuisen…"
+
 msgctxt "#30880"
 msgid "Expert"
 msgstr "Expert"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -140,6 +140,74 @@ def show_catalog_program_season(program, season):
     Catalog().show_program_season(program, int(season))
 
 
+@routing.route('/library/movies/')
+def library_movies():
+    """ Show a list of all movies for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    movie = routing.args.get('movie', [])[0] if routing.args.get('movie') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_movie(movie)
+        return
+
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_movies(movie)
+        return
+
+    if movie:
+        play('movies', movie)
+    else:
+        Library().show_library_movies()
+
+
+@routing.route('/library/tvshows/')
+def library_tvshows():
+    """ Show a list of all tv series for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    program = routing.args.get('program', [])[0] if routing.args.get('program') else None
+    episode = routing.args.get('episode', [])[0] if routing.args.get('episode') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_tvshow(program)
+        return
+
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_tvshows(program)
+        return
+
+    if episode:
+        play('episodes', episode)
+    elif program:
+        Library().show_library_tvshows_program(program)
+    else:
+        Library().show_library_tvshows()
+
+
+@routing.route('/library/configure')
+def library_configure():
+    """ Show information on how to enable the library integration """
+    from resources.lib.modules.library import Library
+    Library().configure()
+
+
+@routing.route('/library/update')
+def library_update():
+    """ Refresh the library. """
+    from resources.lib.modules.library import Library
+    Library().update()
+
+
+@routing.route('/library/clean')
+def library_clean():
+    """ Clean the library. """
+    from resources.lib.modules.library import Library
+    Library().clean()
+
+
 @routing.route('/catalog/recommendations/<storefront>')
 def show_recommendations(storefront):
     """ Shows the recommendations of a storefront """
@@ -167,12 +235,18 @@ def mylist_add(video_type, content_id):
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_add(video_type, content_id)
 
+    from resources.lib.modules.library import Library
+    Library().mylist_added(video_type, content_id)
+
 
 @routing.route('/catalog/mylist/del/<video_type>/<content_id>')
 def mylist_del(video_type, content_id):
     """ Remove an item from "My List" """
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_del(video_type, content_id)
+
+    from resources.lib.modules.library import Library
+    Library().mylist_removed(video_type, content_id)
 
 
 @routing.route('/catalog/continuewatching')

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -225,6 +225,14 @@ def play(stream, license_key=None, title=None, art_dict=None, info_dict=None, pr
     xbmcplugin.setResolvedUrl(routing.handle, True, listitem=play_item)
 
 
+def library_return_status(success):
+    """Notify Kodi about the status of a listitem."""
+    from resources.lib.addon import routing
+
+    _LOGGER.debug('Returning status %s', success)
+    xbmcplugin.setResolvedUrl(routing.handle, success, listitem=xbmcgui.ListItem())
+
+
 def get_search_string(heading='', message=''):
     """Ask the user for a search string"""
     search_string = None
@@ -667,12 +675,19 @@ def get_cache(key, ttl=None):
 def set_cache(key, data):
     """ Store an item in the cache
     :type key: list[str]
-    :type data: str
+    :type data: any
     """
-    if not xbmcvfs.exists(get_cache_path()):
-        xbmcvfs.mkdirs(get_cache_path())
+    fullpath = get_cache_path() + '/'
 
-    fullpath = os.path.join(get_cache_path(), '.'.join(key))
+    if not xbmcvfs.exists(fullpath):
+        xbmcvfs.mkdirs(fullpath)
+
+    fullpath = os.path.join(fullpath, '.'.join(key))
+
+    if data is None:
+        # Remove from cache
+        xbmcvfs.delete(fullpath)
+        return
 
     fdesc = xbmcvfs.File(fullpath, 'w')
 
@@ -685,7 +700,7 @@ def set_cache(key, data):
 
 def invalidate_cache(ttl=None):
     """ Clear the cache """
-    fullpath = get_cache_path()
+    fullpath = get_cache_path() + '/'
 
     if not xbmcvfs.exists(fullpath):
         return

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+""" Library module """
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+
+from resources.lib import kodiutils
+from resources.lib.modules.menu import Menu
+from resources.lib.vtmgo import Movie, Program
+from resources.lib.vtmgo.vtmgo import CACHE_AUTO, CACHE_PREVENT, CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM, VtmGo
+from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
+
+_LOGGER = logging.getLogger(__name__)
+
+LIBRARY_FULL_CATALOG = 0
+LIBRARY_ONLY_MYLIST = 1
+
+
+class Library:
+    """ Menu code related to the catalog """
+
+    def __init__(self):
+        """ Initialise object """
+        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                          kodiutils.get_setting('password'),
+                          kodiutils.get_setting('loginprovider'),
+                          kodiutils.get_setting('profile'),
+                          kodiutils.get_tokens_path())
+        self._api = VtmGo(self._auth)
+
+    def show_library_movies(self, movie=None):
+        """ Return a list of the movies that should be exported. """
+        if movie is None:
+            if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+                # Full catalog
+                # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+                items = self._api.get_items(content_filter=Movie, cache=CACHE_AUTO)
+            else:
+                # Only favourites, use cache if available, fetch from api otherwise
+                items = self._api.get_swimlane('my-list', content_filter=Movie)
+        else:
+            items = [self._api.get_movie(movie)]
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)  # We need a trailing /
+            title_item.path = 'plugin://plugin.video.vtm.go/library/movies/?movie=%s' % item.movie_id
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='movies', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows(self, program=None):
+        """ Return a list of the series that should be exported. """
+        if program is None:
+            if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+                # Full catalog
+                # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+                # NOTE: We should probably use CACHE_PREVENT here, so we can pick up new episodes, but we can't since that would
+                #       require a massive amount of API calls for each update. We do this only for programs in 'My list'.
+                items = self._api.get_items(content_filter=Program, cache=CACHE_AUTO)
+            else:
+                # Only favourites, don't use cache, fetch from api
+                # If we use CACHE_AUTO, we will miss updates until the user manually opens the program in the Add-on
+                items = self._api.get_swimlane('my-list', content_filter=Program, cache=CACHE_PREVENT)
+        else:
+            # Fetch only a single program
+            items = [self._api.get_program(program, cache=CACHE_PREVENT)]
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id)  # We need a trailing /
+            title_item.path = 'plugin://plugin.video.vtm.go/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows_program(self, program):
+        """ Return a list of the episodes that should be exported. """
+        program_obj = self._api.get_program(program)
+
+        listing = []
+        for season in list(program_obj.seasons.values()):
+            for item in list(season.episodes.values()):
+                title_item = Menu.generate_titleitem(item)
+                # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id, episode=item.episode_id)
+                title_item.path = 'plugin://plugin.video.vtm.go/library/tvshows/?program={program_id}&episode={episode_id}'.format(program_id=item.program_id,
+                                                                                                                                    episode_id=item.episode_id)
+                listing.append(title_item)
+
+        # Sort by episode number by default. Takes seasons into account.
+        kodiutils.show_listing(listing, 30003, content='episodes', sort=['episode', 'duration'])
+
+    def check_library_movie(self, movie):
+        """ Check if the given movie is still available. """
+        _LOGGER.debug('Checking if movie %s is still available', movie)
+
+        # Our parent path always exists
+        if movie is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+            id_list = self._api.get_catalog_ids()
+        else:
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(movie in id_list)
+
+    def check_library_tvshow(self, program):
+        """ Check if the given program is still available. """
+        _LOGGER.debug('Checking if program %s is still available', program)
+
+        # Our parent path always exists
+        if program is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+            id_list = self._api.get_catalog_ids()
+        else:
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(program in id_list)
+
+    @staticmethod
+    def mylist_added(video_type, content_id):
+        """ Something has been added to My List. We want to index this. """
+        if video_type == CONTENT_TYPE_MOVIE:
+            if kodiutils.get_setting_int('library_movies') != LIBRARY_ONLY_MYLIST:
+                return
+            # This unfortunately adds the movie to the database with the wrong parent path:
+            # Library().update('plugin://plugin.video.vtm.go/library/movies/?movie=%s&kodi_action=refresh_info' % content_id)
+            Library().update('plugin://plugin.video.vtm.go/library/movies/')
+
+        elif video_type == CONTENT_TYPE_PROGRAM:
+            if kodiutils.get_setting_int('library_tvshows') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().update('plugin://plugin.video.vtm.go/library/tvshows/?program=%s&kodi_action=refresh_info' % content_id)
+
+    @staticmethod
+    def mylist_removed(video_type, content_id):
+        """ Something has been removed from My List. We want to de-index this. """
+        if video_type == CONTENT_TYPE_MOVIE:
+            if kodiutils.get_setting_int('library_movies') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().clean('plugin://plugin.video.vtm.go/library/movies/?movie=%s' % content_id)
+
+        elif video_type == CONTENT_TYPE_PROGRAM:
+            if kodiutils.get_setting_int('library_tvshows') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().clean('plugin://plugin.video.vtm.go/library/tvshows/?program=%s' % content_id)
+
+    @staticmethod
+    def configure():
+        """ Configure the library integration. """
+        # There seems to be no way to add sources automatically.
+        # * https://forum.kodi.tv/showthread.php?tid=228840
+
+        # Open the sources view
+        kodiutils.execute_builtin('ActivateWindow(Videos,sources://video/)')
+
+    @staticmethod
+    def update(path=None):
+        """ Update the library integration. """
+        _LOGGER.debug('Scanning %s', path)
+        if path:
+            # We can use this to instantly add something to the library when we've added it to 'My List'.
+            kodiutils.jsonrpc(method='VideoLibrary.Scan', params=dict(
+                directory=path,
+                showdialogs=False,
+            ))
+        else:
+            kodiutils.jsonrpc(method='VideoLibrary.Scan')
+
+    @staticmethod
+    def clean(path=None):
+        """ Cleanup the library integration. """
+        _LOGGER.debug('Cleaning %s', path)
+        if path:
+            # We can use this to instantly remove something from the library when we've removed it from 'My List'.
+            # This only works from Kodi 19 however. See https://github.com/xbmc/xbmc/pull/18562
+            if kodiutils.kodi_version_major() > 18:
+                kodiutils.jsonrpc(method='VideoLibrary.Clean', params=dict(
+                    directory=path,
+                    showdialogs=False,
+                ))
+            else:
+                kodiutils.jsonrpc(method='VideoLibrary.Clean', params=dict(
+                    showdialogs=False,
+                ))
+        else:
+            kodiutils.jsonrpc(method='VideoLibrary.Clean')

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -23,10 +23,10 @@ class Library:
     def __init__(self):
         """ Initialise object """
         self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                          kodiutils.get_setting('password'),
-                          kodiutils.get_setting('loginprovider'),
-                          kodiutils.get_setting('profile'),
-                          kodiutils.get_tokens_path())
+                               kodiutils.get_setting('password'),
+                               kodiutils.get_setting('loginprovider'),
+                               kodiutils.get_setting('profile'),
+                               kodiutils.get_tokens_path())
         self._api = VtmGo(self._auth)
 
     def show_library_movies(self, movie=None):
@@ -87,7 +87,7 @@ class Library:
                 title_item = Menu.generate_titleitem(item)
                 # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id, episode=item.episode_id)
                 title_item.path = 'plugin://plugin.video.vtm.go/library/tvshows/?program={program_id}&episode={episode_id}'.format(program_id=item.program_id,
-                                                                                                                                    episode_id=item.episode_id)
+                                                                                                                                   episode_id=item.episode_id)
                 listing.append(title_item)
 
         # Sort by episode number by default. Takes seasons into account.

--- a/resources/lib/modules/menu.py
+++ b/resources/lib/modules/menu.py
@@ -218,7 +218,8 @@ class Menu:
 
         return plot.rstrip()
 
-    def generate_titleitem(self, item, progress=False):
+    @classmethod
+    def generate_titleitem(cls, item, progress=False):
         """ Generate a TitleItem based on a Movie, Program or Episode.
         :type item: Union[Movie, Program, Episode]
         :type progress: bool
@@ -230,7 +231,7 @@ class Menu:
         }
         info_dict = {
             'title': item.name,
-            'plot': self.format_plot(item),
+            'plot': cls.format_plot(item),
             'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
             'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else kodiutils.localize(30216),  # All ages
         }
@@ -275,6 +276,7 @@ class Menu:
                 art_dict=art_dict,
                 info_dict=info_dict,
                 stream_dict=stream_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
                 is_playable=True,
             )
@@ -300,8 +302,11 @@ class Menu:
                 'fanart': item.image,
             })
             info_dict.update({
-                'mediatype': None,
+                'mediatype': 'tvshow',
                 'season': len(item.seasons),
+            })
+            prop_dict.update({
+                'hash': item.content_hash,
             })
 
             return kodiutils.TitleItem(
@@ -309,6 +314,7 @@ class Menu:
                 path=kodiutils.url_for('show_catalog_program', program=item.program_id),
                 art_dict=art_dict,
                 info_dict=info_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
             )
 

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -44,7 +44,7 @@ class Metadata:
         """ Fetch the metadata for all the items in the catalog
         :type callback: callable
         """
-        # Fetch all items from the catalog
+        # Fetch a list of all items from the catalog
         items = self._vtm_go.get_items()
         count = len(items)
 

--- a/resources/lib/vtmgo/__init__.py
+++ b/resources/lib/vtmgo/__init__.py
@@ -12,6 +12,7 @@ STOREFRONT_SERIES = '1c683de4-3fb0-4cc4-9d9c-c365eba1b155'
 STOREFRONT_KIDS = '73f34fbf-301c-4deb-b366-13ba39e25996'
 STOREFRONT_KIDS_MAIN = '11575a66-af71-4025-8e57-d691a7520773'
 
+
 class Profile:
     """ Defines a profile under your account. """
 
@@ -138,7 +139,7 @@ class Program:
     """ Defines a Program """
 
     def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
-                 geoblocked=None, channel=None, legal=None, my_list=None):
+                 geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None):
         """
         :type program_id: str
         :type name: str
@@ -150,6 +151,7 @@ class Program:
         :type channel: str
         :type legal: str
         :type my_list: bool
+        :type content_hash: str
         """
         self.program_id = program_id
         self.name = name
@@ -161,6 +163,7 @@ class Program:
         self.channel = channel
         self.legal = legal
         self.my_list = my_list
+        self.content_hash = content_hash
 
     def __repr__(self):
         return "%r" % self.__dict__
@@ -235,6 +238,33 @@ class Episode:
         self.progress = progress
         self.watched = watched
         self.next_episode = next_episode
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class ResolvedStream:
+    """ Defines a stream that we can play"""
+
+    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_url=None, subtitles=None, cookies=None):
+        """
+        :type program: str|None
+        :type program_id: int|None
+        :type title: str
+        :type duration: str|None
+        :type url: str
+        :type license_url: str
+        :type subtitles: list[str]
+        :type cookies: dict
+        """
+        self.program = program
+        self.program_id = program_id
+        self.title = title
+        self.duration = duration
+        self.url = url
+        self.license_url = license_url
+        self.subtitles = subtitles
+        self.cookies = cookies
 
     def __repr__(self):
         return "%r" % self.__dict__

--- a/resources/lib/vtmgo/exceptions.py
+++ b/resources/lib/vtmgo/exceptions.py
@@ -34,3 +34,6 @@ class StreamGeoblockedException(Exception):
 
 class StreamUnavailableException(Exception):
     """ Is thrown when an unavailable item is played. """
+
+class LimitReachedException(Exception):
+    """ Is thrown when the limit is reached to play an stream. """

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
+import hashlib
 import json
 import logging
 
@@ -84,7 +85,7 @@ class VtmGo:
 
         return categories
 
-    def get_swimlane(self, swimlane=None):
+    def get_swimlane(self, swimlane, content_filter=None, cache=CACHE_ONLY):
         """ Returns the contents of My List """
         response = util.http_get(API_ENDPOINT + '/%s/main/swimlane/%s' % (self._mode(), swimlane),
                                  token=self._tokens.jwt_token,
@@ -98,14 +99,14 @@ class VtmGo:
 
         items = []
         for item in result.get('teasers'):
-            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
-                items.append(self._parse_movie_teaser(item))
+            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE and content_filter in [None, Movie]:
+                items.append(self._parse_movie_teaser(item, cache=cache))
 
-            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
-                items.append(self._parse_program_teaser(item))
+            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM and content_filter in [None, Program]:
+                items.append(self._parse_program_teaser(item, cache=cache))
 
-            elif item.get('target', {}).get('type') == CONTENT_TYPE_EPISODE:
-                items.append(self._parse_episode_teaser(item))
+            elif item.get('target', {}).get('type') == CONTENT_TYPE_EPISODE and content_filter in [None, Episode]:
+                items.append(self._parse_episode_teaser(item, cache=cache))
 
         return items
 
@@ -114,12 +115,14 @@ class VtmGo:
         util.http_put(API_ENDPOINT + '/%s/userData/myList/%s/%s' % (self._mode(), video_type, content_id),
                       token=self._tokens.jwt_token,
                       profile=self._tokens.profile)
+        kodiutils.set_cache(['swimlane', 'my-list'], None)
 
     def del_mylist(self, video_type, content_id):
         """ Delete an item from My List """
         util.http_delete(API_ENDPOINT + '/%s/userData/myList/%s/%s' % (self._mode(), video_type, content_id),
                          token=self._tokens.jwt_token,
                          profile=self._tokens.profile)
+        kodiutils.set_cache(['swimlane', 'my-list'], None)
 
     def get_live_channels(self):
         """ Get a list of all the live tv channels.
@@ -176,30 +179,29 @@ class VtmGo:
 
         return categories
 
-    def get_items(self, category=None):
+    def get_items(self, category=None, content_filter=None, cache=CACHE_ONLY):
         """ Get a list of all the items in a category.
+
         :type category: str
-        :rtype list[Union[Movie, Program]]
+        :type content_filter: class
+        :type cache: int
+        :rtype list[resources.lib.vtmgo.Movie | resources.lib.vtmgo.Program]
         """
         # Fetch from API
-        if category is None:
-            response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(), {'pageSize': 1000},
-                                     token=self._tokens.jwt_token,
-                                     profile=self._tokens.profile)
-        else:
-            response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(), {'pageSize': 1000, 'filter': quote(category)},
-                                     token=self._tokens.jwt_token,
-                                     profile=self._tokens.profile)
+        response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(),
+                                 params={'pageSize': 2000, 'filter': quote(category) if category else None},
+                                 token=self._tokens.jwt_token,
+                                 profile=self._tokens.profile)
         info = json.loads(response.text)
         content = info.get('pagedTeasers', {}).get('content', [])
 
         items = []
         for item in content:
-            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
-                items.append(self._parse_movie_teaser(item))
+            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE and content_filter in [None, Movie]:
+                items.append(self._parse_movie_teaser(item, cache=cache))
 
-            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
-                items.append(self._parse_program_teaser(item))
+            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM and content_filter in [None, Program]:
+                items.append(self._parse_program_teaser(item, cache=cache))
 
         return items
 
@@ -266,6 +268,10 @@ class VtmGo:
 
         channel = self._parse_channel(program.get('channelLogoUrl'))
 
+        # Calculate a hash value of the ids of all episodes
+        program_hash = hashlib.md5()
+        program_hash.update(program.get('id').encode())
+
         seasons = {}
         for item_season in program.get('seasons', []):
             episodes = {}
@@ -289,6 +295,7 @@ class VtmGo:
                     progress=item_episode.get('playerPositionSeconds', 0),
                     watched=item_episode.get('doneWatching', False),
                 )
+                program_hash.update(item_episode.get('id').encode())
 
             seasons[item_season.get('index')] = Season(
                 number=item_season.get('index'),
@@ -310,6 +317,8 @@ class VtmGo:
             seasons=seasons,
             channel=channel,
             legal=program.get('legalIcons'),
+            content_hash=program_hash.hexdigest().upper(),
+            # my_list=program.get('addedToMyList'),  # Don't use addedToMyList, since we might have cached this info
         )
 
     @staticmethod
@@ -381,6 +390,45 @@ class VtmGo:
             next_episode=next_episode,
         )
 
+    def get_mylist_ids(self):
+        """ Returns the IDs of the contents of My List """
+        # Try to fetch from cache
+        items = kodiutils.get_cache(['mylist_id'], 300)  # 5 minutes ttl
+        if items:
+            return items
+
+        # Fetch from API
+        response = util.http_get(API_ENDPOINT + '/%s/main/swimlane/%s' % (self._mode(), 'my-list'),
+                                 token=self._tokens.jwt_token,
+                                 profile=self._tokens.profile)
+
+        # Result can be empty
+        result = json.loads(response.text) if response.text else []
+
+        items = [item.get('target', {}).get('id') for item in result.get('teasers', [])]
+
+        kodiutils.set_cache(['mylist_id'], items)
+        return items
+
+    def get_catalog_ids(self):
+        """ Returns the IDs of the contents of the Catalog """
+        # Try to fetch from cache
+        items = kodiutils.get_cache(['catalog_id'], 300)  # 5 minutes ttl
+        if items:
+            return items
+
+        # Fetch from API
+        response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(),
+                                 params={'pageSize': 2000, 'filter': None},
+                                 token=self._tokens.jwt_token,
+                                 profile=self._tokens.profile)
+        info = json.loads(response.text)
+
+        items = [item.get('target', {}).get('id') for item in info.get('pagedTeasers', {}).get('content', [])]
+
+        kodiutils.set_cache(['catalog_id'], items)
+        return items
+
     def do_search(self, search):
         """ Do a search in the full catalog.
         :type search: str
@@ -411,12 +459,13 @@ class VtmGo:
         except (IndexError, AttributeError):
             return None
 
-    def _parse_movie_teaser(self, item):
+    def _parse_movie_teaser(self, item, cache=CACHE_ONLY):
         """ Parse the movie json and return an Movie instance.
         :type item: dict
+        :type cache: int
         :rtype Movie
         """
-        movie = self.get_movie(item.get('target', {}).get('id'), cache=CACHE_ONLY)
+        movie = self.get_movie(item.get('target', {}).get('id'), cache=cache)
         if movie:
             # We have a cover from the overview that we don't have in the details
             movie.cover = item.get('imageUrl')
@@ -430,12 +479,13 @@ class VtmGo:
             geoblocked=item.get('geoBlocked'),
         )
 
-    def _parse_program_teaser(self, item):
+    def _parse_program_teaser(self, item, cache=CACHE_ONLY):
         """ Parse the program json and return an Program instance.
         :type item: dict
+        :type cache: int
         :rtype Program
         """
-        program = self.get_program(item.get('target', {}).get('id'), cache=CACHE_ONLY)
+        program = self.get_program(item.get('target', {}).get('id'), cache=cache)
         if program:
             # We have a cover from the overview that we don't have in the details
             program.cover = item.get('imageUrl')
@@ -449,12 +499,13 @@ class VtmGo:
             geoblocked=item.get('geoBlocked'),
         )
 
-    def _parse_episode_teaser(self, item):
+    def _parse_episode_teaser(self, item, cache=CACHE_ONLY):
         """ Parse the episode json and return an Episode instance.
         :type item: dict
+        :type cache: int
         :rtype Episode
         """
-        program = self.get_program(item.get('target', {}).get('programId'), cache=CACHE_ONLY)
+        program = self.get_program(item.get('target', {}).get('programId'), cache=cache)
         episode = self.get_episode_from_program(program, item.get('target', {}).get('id')) if program else None
 
         return Episode(

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -10,44 +10,10 @@ import random
 from datetime import timedelta
 
 from resources.lib import kodiutils
-from resources.lib.vtmgo import util
+from resources.lib.vtmgo import util, ResolvedStream
+from resources.lib.vtmgo.exceptions import StreamGeoblockedException, StreamUnavailableException
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class StreamGeoblockedException(Exception):
-    """ Is thrown when a geoblocked item is played. """
-
-
-class StreamUnavailableException(Exception):
-    """ Is thrown when an unavailable item is played. """
-
-
-class ResolvedStream:
-    """ Defines a stream that we can play"""
-
-    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_url=None, subtitles=None, cookies=None):
-        """
-        :type program: str|None
-        :type program_id: int|None
-        :type title: str
-        :type duration: str|None
-        :type url: str
-        :type license_url: str
-        :type subtitles: list[str]
-        :type cookies: dict
-        """
-        self.program = program
-        self.program_id = program_id
-        self.title = title
-        self.duration = duration
-        self.url = url
-        self.license_url = license_url
-        self.subtitles = subtitles
-        self.cookies = cookies
-
-    def __repr__(self):
-        return "%r" % self.__dict__
 
 
 class VtmGoStream:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -26,6 +26,15 @@
         <setting label="30843" type="lsep"/> <!-- Streaming -->
         <setting label="30844" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
     </category>
+    <category label="30870"> <!-- Kodi Library -->
+        <setting label="30871" type="lsep"/> <!-- Indexing -->
+        <setting label="30872" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/configure)" option="close"/>
+        <setting label="30873" type="select" id="library_movies" default="1" lvalues="30875|30876"/>
+        <setting label="30874" type="select" id="library_tvshows" default="1" lvalues="30875|30876"/>
+        <setting label="30877" type="lsep"/> <!-- Maintenance -->
+        <setting label="30878" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/update)"/>
+        <setting label="30879" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/clean)"/>
+    </category>
     <category label="30860"> <!-- Integrations -->
         <setting label="30861" type="lsep"/> <!-- Up Next -->
         <setting label="30862" type="action" action="InstallAddon(service.upnext)" option="close" visible="!System.HasAddon(service.upnext)"/>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,6 +100,13 @@ class TestApi(unittest.TestCase):
             # TODO: fix this
             pass
 
+    def test_mylist_ids(self):
+        mylist = self._vtmgo.get_mylist_ids()
+        self.assertIsInstance(mylist, list)
+
+    def test_catalog_ids(self):
+        mylist = self._vtmgo.get_catalog_ids()
+        self.assertIsInstance(mylist, list)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allows to integrate the movies and tv series into Kodi. You have the option to configure the behaviour to export everything or only the items in "My List". This can be configured separately for movies and series. When switching from a full export to "My List", you need to run Library cleanup for the other items to be removed from your library.

When running a library cleanup, we take a snapshot of all ids's in the catalog (or in my list if you only export that) and check if they are in that list. This is a lot faster than using the API, and is also more correct compared with if we would use the cache.

See https://github.com/add-ons/plugin.video.streamz/pull/9

Fixes #221 