### PR TITLE
Use xbmcvfs.translatePath when it is available

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -112,7 +112,7 @@ def addon_path():
 
 def addon_profile():
     """Cache and return add-on profile"""
-    if kodi_version_major() >= 19:
+    if hasattr(xbmcvfs, 'translatePath'):
         translate_path = xbmcvfs.translatePath
     else:
         translate_path = xbmc.translatePath

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -112,11 +112,10 @@ def addon_path():
 
 def addon_profile():
     """Cache and return add-on profile"""
-    if hasattr(xbmcvfs, 'translatePath'):
-        translate_path = xbmcvfs.translatePath
-    else:
-        translate_path = xbmc.translatePath
-    return to_unicode(translate_path(ADDON.getAddonInfo('profile')))
+    try:  # Kodi 19
+        return to_unicode(xbmcvfs.translatePath(ADDON.getAddonInfo('profile')))
+    except AttributeError:  # Kodi 18
+        return to_unicode(xbmc.translatePath(ADDON.getAddonInfo('profile')))
 
 
 def url_for(name, *args, **kwargs):


### PR DESCRIPTION
I am running the latest milhouse build of Libreelec (kodi matrix). It runs 19, but does not yet have `xbmcvfs.translatePath`. So I propose to change the check to something more robust.