### PR TITLE
Allow displaying all items in a recommendation category

### DIFF
--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -8,6 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
 from resources.lib.modules.menu import Menu
+from resources.lib.vtmgo import Category, STOREFRONT_MOVIES, STOREFRONT_SERIES
 from resources.lib.vtmgo.exceptions import UnavailableException
 from resources.lib.vtmgo.vtmgo import CACHE_PREVENT, ApiUpdateRequired, VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
@@ -75,7 +76,7 @@ class Catalog:
 
         # Sort items by label, but don't put folders at the top.
         # Used for A-Z listing or when movies and episodes are mixed.
-        kodiutils.show_listing(listing, 30003, content='movies' if category == 'films' else 'tvshows', sort=['label', 'year', 'duration'])
+        kodiutils.show_listing(listing, 30003, content='files', sort=['label', 'year', 'duration'])
 
     def show_catalog_channel(self, channel):
         """ Show a category in the catalog
@@ -160,7 +161,7 @@ class Catalog:
             ))
 
         # Sort by label. Some programs return seasons unordered.
-        kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label'])
+        kodiutils.show_listing(listing, program_obj.name, content='tvshows', sort=['label'])
 
     def show_program_season(self, program, season):
         """ Show the episodes of a program from the catalog
@@ -184,7 +185,7 @@ class Catalog:
         listing = [self._menu.generate_titleitem(e) for s in seasons for e in list(s.episodes.values())]
 
         # Sort by episode number by default. Takes seasons into account.
-        kodiutils.show_listing(listing, 30003, content='episodes', sort=['episode', 'duration'])
+        kodiutils.show_listing(listing, program_obj.name, content='episodes', sort=['episode', 'duration'])
 
     def show_recommendations(self, storefront):
         """ Show the recommendations.
@@ -192,7 +193,7 @@ class Catalog:
         :type storefront: str
         """
         try:
-            recommendations = self._vtm_go.get_recommendations(storefront)
+            results = self._vtm_go.get_storefront(storefront)
         except ApiUpdateRequired:
             kodiutils.ok_dialog(message=kodiutils.localize(30705))  # The VTM GO Service has been updated...
             return
@@ -203,17 +204,26 @@ class Catalog:
             return
 
         listing = []
-        for cat in recommendations:
-            listing.append(kodiutils.TitleItem(
-                title=cat.title,
-                path=kodiutils.url_for('show_recommendations_category', storefront=storefront, category=cat.category_id),
-                info_dict=dict(
-                    plot='[B]{category}[/B]'.format(category=cat.title),
-                ),
-            ))
+        for item in results:
+            if isinstance(item, Category):
+                listing.append(kodiutils.TitleItem(
+                    title=item.title,
+                    path=kodiutils.url_for('show_recommendations_category', storefront=storefront, category=item.category_id),
+                    info_dict=dict(
+                        plot='[B]{category}[/B]'.format(category=item.title),
+                    ),
+                ))
+            else:
+                listing.append(self._menu.generate_titleitem(item))
 
-        # Sort categories by default like in VTM GO.
-        kodiutils.show_listing(listing, 30015, content='files')
+        if storefront == STOREFRONT_SERIES:
+            label = 30005  # Series
+        elif storefront == STOREFRONT_MOVIES:
+            label = 30003  # Movies
+        else:
+            label = 30015  # Recommendations
+
+        kodiutils.show_listing(listing, label, content='files')
 
     def show_recommendations_category(self, storefront, category):
         """ Show the items in a recommendations category.
@@ -222,7 +232,7 @@ class Catalog:
         :type category: str
         """
         try:
-            recommendations = self._vtm_go.get_recommendations(storefront)
+            result = self._vtm_go.get_storefront_category(storefront, category)
         except ApiUpdateRequired:
             kodiutils.ok_dialog(message=kodiutils.localize(30705))  # The VTM GO Service has been updated...
             return
@@ -233,16 +243,17 @@ class Catalog:
             return
 
         listing = []
-        for cat in recommendations:
-            # Only show the requested category
-            if cat.category_id != category:
-                continue
+        for item in result.content:
+            listing.append(self._menu.generate_titleitem(item))
 
-            for item in cat.content:
-                listing.append(self._menu.generate_titleitem(item))
+        if storefront == STOREFRONT_SERIES:
+            content = 'tvshows'
+        elif storefront == STOREFRONT_MOVIES:
+            content = 'movies'
+        else:
+            content = 'files'
 
-        # Sort categories by default like in VTM GO.
-        kodiutils.show_listing(listing, 30015, content='tvshows')
+        kodiutils.show_listing(listing, result.title, content=content, sort=['unsorted', 'label', 'year', 'duration'])
 
     def show_mylist(self):
         """ Show the items in "My List" """
@@ -262,8 +273,7 @@ class Catalog:
             item.my_list = True
             listing.append(self._menu.generate_titleitem(item))
 
-        # Sort categories by default like in VTM GO.
-        kodiutils.show_listing(listing, 30017, content='tvshows')
+        kodiutils.show_listing(listing, 30017, content='files', sort=['unsorted', 'label', 'year', 'duration'])
 
     def mylist_add(self, video_type, content_id):
         """ Add an item to "My List"

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -52,38 +52,69 @@ class VtmGo:
         # This contains a player.updateIntervalSeconds that could be used to notify VTM GO about the playing progress
         return info
 
-    def get_recommendations(self, storefront):
-        """ Returns the config for the dashboard.
+    def get_storefront(self, storefront):
+        """ Returns a storefront.
 
-         :param str storefront:         The ID of the listing.
-         :rtype: list[Category]
+         :param str storefront:         The ID of the storefront.
+         :rtype: list[Category|Program|Movie]
          """
         response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s' % (self._mode(), storefront),
                                  token=self._tokens.jwt_token,
                                  profile=self._tokens.profile)
-        recommendations = json.loads(response.text)
+        result = json.loads(response.text)
 
-        categories = []
-        for cat in recommendations.get('rows', []):
-            if cat.get('rowType') not in ['SWIMLANE_DEFAULT']:
-                _LOGGER.debug('Skipping recommendation %s with type %s', cat.get('title'), cat.get('rowType'))
+        items = []
+        for row in result.get('rows', []):
+            if row.get('rowType') == 'SWIMLANE_DEFAULT':
+                items.append(Category(
+                    category_id=row.get('id'),
+                    title=row.get('title'),
+                ))
                 continue
 
-            items = []
-            for item in cat.get('teasers'):
+            if row.get('rowType') == 'CAROUSEL':
+                for item in row.get('teasers'):
+                    if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
+                        items.append(self._parse_movie_teaser(item))
+
+                    elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
+                        items.append(self._parse_program_teaser(item))
+                continue
+
+            if row.get('rowType') == 'MARKETING_BLOCK':
+                item = row.get('teaser')
                 if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                     items.append(self._parse_movie_teaser(item))
 
                 elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
                     items.append(self._parse_program_teaser(item))
+                continue
 
-            categories.append(Category(
-                category_id=cat.get('id'),
-                title=cat.get('title'),
-                content=items,
-            ))
+            _LOGGER.debug('Skipping recommendation %s with type %s', row.get('title'), row.get('rowType'))
 
-        return categories
+        return items
+
+    def get_storefront_category(self, storefront, category):
+        """ Returns a storefront.
+
+         :param str storefront:         The ID of the storefront.
+         :param str category:           The ID of the category.
+         :rtype: Category
+         """
+        response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s/detail/%s' % (self._mode(), storefront, category),
+                                 token=self._tokens.jwt_token,
+                                 profile=self._tokens.profile)
+        result = json.loads(response.text)
+
+        items = []
+        for item in result.get('row', {}).get('teasers'):
+            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
+                items.append(self._parse_movie_teaser(item))
+
+            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
+                items.append(self._parse_program_teaser(item))
+
+        return Category(category_id=category, title=result.get('row', {}).get('title'), content=items)
 
     def get_swimlane(self, swimlane, content_filter=None, cache=CACHE_ONLY):
         """ Returns the contents of My List """
@@ -467,8 +498,9 @@ class VtmGo:
         """
         movie = self.get_movie(item.get('target', {}).get('id'), cache=cache)
         if movie:
-            # We have a cover from the overview that we don't have in the details
-            movie.cover = item.get('imageUrl')
+            # We might have a cover from the overview that we don't have in the details
+            if item.get('imageUrl'):
+                movie.cover = item.get('imageUrl')
             return movie
 
         return Movie(
@@ -487,8 +519,9 @@ class VtmGo:
         """
         program = self.get_program(item.get('target', {}).get('id'), cache=cache)
         if program:
-            # We have a cover from the overview that we don't have in the details
-            program.cover = item.get('imageUrl')
+            # We might have a cover from the overview that we don't have in the details
+            if item.get('imageUrl'):
+                program.cover = item.get('imageUrl')
             return program
 
         return Program(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ import xbmc
 
 from resources.lib import kodiutils
 from resources.lib.modules.player import Player
-from resources.lib.vtmgo import Movie, Program
+from resources.lib.vtmgo import Movie, Program, Category
 from resources.lib.vtmgo import vtmgo, vtmgostream, vtmgoauth, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SERIES
 from resources.lib.vtmgo.vtmgostream import StreamGeoblockedException
 
@@ -69,14 +69,18 @@ class TestApi(unittest.TestCase):
             pass
 
     def test_recommendations(self):
-        main_recommendations = self._vtmgo.get_recommendations(STOREFRONT_MAIN)
-        self.assertIsInstance(main_recommendations, list)
+        results = self._vtmgo.get_storefront(STOREFRONT_MAIN)
+        self.assertIsInstance(results, list)
 
-        movie_recommendations = self._vtmgo.get_recommendations(STOREFRONT_MOVIES)
-        self.assertIsInstance(movie_recommendations, list)
+        results = self._vtmgo.get_storefront_category(STOREFRONT_MOVIES, '9ab6cd7b-ee12-4177-b205-6e8cefea9833')  # Drama
+        self.assertIsInstance(results, Category)
+        self.assertIsInstance(results.content, list)
 
-        serie_recommendations = self._vtmgo.get_recommendations(STOREFRONT_SERIES)
-        self.assertIsInstance(serie_recommendations, list)
+        results = self._vtmgo.get_storefront(STOREFRONT_MOVIES)
+        self.assertIsInstance(results, list)
+
+        results = self._vtmgo.get_storefront(STOREFRONT_SERIES)
+        self.assertIsInstance(results, list)
 
     def test_mylist(self):
         mylist = self._vtmgo.get_swimlane('my-list')


### PR DESCRIPTION
* Use an API to fetch the details of the categories instead of using the overview that is limited to 40 items. This allows to display more then 40 items in a category, and also speeds up the loading of the overview of the categories since we don't need to parse everything there.
* Show highlighted movies or series inside recommendations / movies / series.
* Improve breadcrumbs
