### PR TITLE
Fix token invalidation when using the Library-feature

### DIFF
--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -24,7 +24,7 @@ class Library:
         """ Initialise object """
         self._auth = VtmGoAuth(kodiutils.get_setting('username'),
                                kodiutils.get_setting('password'),
-                               kodiutils.get_setting('loginprovider'),
+                               'VTM',
                                kodiutils.get_setting('profile'),
                                kodiutils.get_tokens_path())
         self._api = VtmGo(self._auth)

--- a/resources/lib/vtmgo/util.py
+++ b/resources/lib/vtmgo/util.py
@@ -142,7 +142,12 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
     :rtype: requests.Response
     """
     if form or data:
-        _LOGGER.debug('Sending %s %s: %s', method, url, form or data)
+        # Make sure we don't log the password
+        debug_data = dict()
+        debug_data.update(form or data)
+        if 'password' in debug_data:
+            debug_data['password'] = '**redacted**'
+        _LOGGER.debug('Sending %s %s: %s', method, url, debug_data)
     else:
         _LOGGER.debug('Sending %s %s', method, url)
 


### PR DESCRIPTION
When using the library-feature, the cache would be invalidated because an empty `loginprovider` was passed. Also, make sure that we don't log passwords in our debug logs.