### PR TITLE
Fix subtitles when there are more than one

### DIFF
--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -81,7 +81,7 @@ class PlayerMonitor(Player):
         self.__listen = False
         self.__av_started = False
         self.__path = None
-        self.__subtitle_path = None
+        self.__subtitle_paths = None
         Player.__init__(self)
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
@@ -92,7 +92,7 @@ class PlayerMonitor(Player):
             return
         self.__listen = True
         _LOGGER.debug('Player: [onPlayBackStarted] called')
-        self.__subtitle_path = None
+        self.__subtitle_paths = None
         self.__av_started = False
 
     def onAVStarted(self):  # pylint: disable=invalid-name
@@ -100,7 +100,7 @@ class PlayerMonitor(Player):
         if not self.__listen:
             return
         _LOGGER.debug('Player: [onAVStarted] called')
-        self.__subtitle_path = self.__get_subtitle_path()
+        self.__subtitle_paths = self.__get_subtitle_paths()
         self.__av_started = True
         self.__check_subtitles()
 
@@ -129,9 +129,10 @@ class PlayerMonitor(Player):
             _LOGGER.debug('Player: No internal subtitles found')
 
             # Add external subtitles
-            if self.__subtitle_path:
-                _LOGGER.debug('Player: Adding external subtitles %s', self.__subtitle_path)
-                self.setSubtitles(self.__subtitle_path)
+            if self.__subtitle_paths:
+                for subtitle in self.__subtitle_paths:
+                    _LOGGER.debug('Player: Adding external subtitles %s', subtitle)
+                    self.setSubtitles(subtitle)
 
         # Enable subtitles if needed
         show_subtitles = kodiutils.get_setting_bool('showsubtitles')
@@ -154,7 +155,7 @@ class PlayerMonitor(Player):
             return
         _LOGGER.debug('Player: [onPlayBackEnded] called')
         self.__av_started = False
-        self.__subtitle_path = None
+        self.__subtitle_paths = None
 
     def onPlayBackStopped(self):  # pylint: disable=invalid-name
         """ Will be called when [user] stops Kodi playing a file """
@@ -162,7 +163,7 @@ class PlayerMonitor(Player):
             return
         _LOGGER.debug('Player: [onPlayBackStopped] called')
         self.__av_started = False
-        self.__subtitle_path = None
+        self.__subtitle_paths = None
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """ Will be called when playback stops due to an error. """
@@ -170,17 +171,17 @@ class PlayerMonitor(Player):
             return
         _LOGGER.debug('Player: [onPlayBackError] called')
         self.__av_started = False
-        self.__subtitle_path = None
+        self.__subtitle_paths = None
 
     @staticmethod
-    def __get_subtitle_path():
+    def __get_subtitle_paths():
         """ Get the external subtitles path """
         temp_path = kodiutils.addon_profile() + 'temp/'
         files = None
         if kodiutils.exists(temp_path):
             _, files = kodiutils.listdir(temp_path)
-        if files and len(files) == 1:
-            return temp_path + kodiutils.to_unicode(files[0])
+        if files and len(files) >= 1:
+            return [temp_path + kodiutils.to_unicode(filename) for filename in files]
         _LOGGER.debug('Player: No subtitle path')
         return None
 

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -170,12 +170,12 @@ class VtmGoStream:
         """
         subtitles = list()
         if stream_info.get('video').get('subtitles'):
-            for idx, subtitle in enumerate(stream_info.get('video').get('subtitles')):
-                program = stream_info.get('video').get('metadata').get('program')
-                if program:
-                    name = '{} - {}_{}'.format(program.get('title'), stream_info.get('video').get('metadata').get('title'), idx)
-                else:
-                    name = '{}_{}'.format(stream_info.get('video').get('metadata').get('title'), idx)
+            for _, subtitle in enumerate(stream_info.get('video').get('subtitles')):
+                name = subtitle.get('language')
+                if name == 'nl':
+                    name = 'nl.default'
+                elif name == 'nl-tt':
+                    name = 'nl.T888'
                 subtitles.append(dict(name=name, url=subtitle.get('url')))
                 _LOGGER.debug('Found subtitle url %s', subtitle.get('url'))
         return subtitles
@@ -217,8 +217,7 @@ class VtmGoStream:
         _, files = kodiutils.listdir(temp_dir)
         if files:
             for item in files:
-                if kodiutils.to_unicode(item).endswith('.vtt'):
-                    kodiutils.delete(temp_dir + kodiutils.to_unicode(item))
+                kodiutils.delete(temp_dir + kodiutils.to_unicode(item))
 
         # Return if there are no subtitles available
         if not subtitles:
@@ -240,7 +239,7 @@ class VtmGoStream:
             )
 
         for subtitle in subtitles:
-            output_file = temp_dir + subtitle.get('name') + '.' + subtitle.get('url').split('.')[-1]
+            output_file = temp_dir + subtitle.get('name')
             webvtt_content = util.http_get(subtitle.get('url')).text
             webvtt_content = webvtt_timing_regex.sub(lambda match: self._delay_webvtt_timing(match, ad_breaks), webvtt_content)
             with kodiutils.open_file(output_file, 'w') as webvtt_output:


### PR DESCRIPTION
* Support multiple subtitles
* Use naming as on the VTM Go site (`Nederlands` and `Nederlands - T888`)
* Set subtitle `Nederlands` as default (as it is on the VTM Go site)

Things to notice: 
* We can't push metadata about a subtitle to kodi, so we have to craft a filename that Kodi can use. That code is here: https://github.com/xbmc/xbmc/blob/Leia/xbmc/Util.cpp#L2099
* Kodi doesn't care about the extension, so I omit it since this causes an ugly vtt to be shown in the subtitle name.

![image](https://user-images.githubusercontent.com/1193779/103363273-f897c300-4aba-11eb-8b1d-e31df50012cc.png)
