### PR TITLE
Don't depend on credentials to populate IPTV Manager data

### DIFF
--- a/resources/lib/modules/iptvmanager.py
+++ b/resources/lib/modules/iptvmanager.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
 from resources.lib.vtmgo.vtmgo import VtmGo
-from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 from resources.lib.vtmgo.vtmgoepg import VtmGoEpg
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,12 +23,7 @@ class IPTVManager:
         """ Initialise object
         :type port: int
         """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
-        self._vtm_go = VtmGo(self._auth)
+        self._vtm_go = VtmGo()
         self._vtm_go_epg = VtmGoEpg()
         self.port = port
 

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -7,6 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.vtmgo import Movie, Program
+from resources.lib.vtmgo.exceptions import NoLoginException
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
@@ -18,11 +19,14 @@ class Metadata:
 
     def __init__(self):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
+        try:
+            self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                                   kodiutils.get_setting('password'),
+                                   'VTM',
+                                   kodiutils.get_setting('profile'),
+                                   kodiutils.get_tokens_path())
+        except NoLoginException:
+            self._auth = None
         self._vtm_go = VtmGo(self._auth)
 
     def update(self):

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -26,8 +26,7 @@ class Player:
                                    'VTM',
                                    kodiutils.get_setting('profile'),
                                    kodiutils.get_tokens_path())
-        except NoLoginException as exc:
-            _LOGGER.warning(exc)
+        except NoLoginException:
             self._auth = None
 
         self._vtm_go = VtmGo(self._auth)

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -7,7 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.kodiplayer import KodiPlayer
-from resources.lib.vtmgo.exceptions import StreamGeoblockedException, StreamUnavailableException, UnavailableException
+from resources.lib.vtmgo.exceptions import NoLoginException, StreamGeoblockedException, StreamUnavailableException, UnavailableException
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 from resources.lib.vtmgo.vtmgostream import VtmGoStream
@@ -20,13 +20,18 @@ class Player:
 
     def __init__(self):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
+        try:
+            self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                                   kodiutils.get_setting('password'),
+                                   'VTM',
+                                   kodiutils.get_setting('profile'),
+                                   kodiutils.get_tokens_path())
+        except NoLoginException as exc:
+            _LOGGER.warning(exc)
+            self._auth = None
+
         self._vtm_go = VtmGo(self._auth)
-        self._vtm_go_stream = VtmGoStream()
+        self._vtm_go_stream = VtmGoStream(self._auth)
 
     def play_or_live(self, category, item, channel):
         """ Ask to play the requested item or switch to the live channel

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -33,10 +33,10 @@ class ApiUpdateRequired(Exception):
 class VtmGo:
     """ VTM GO API """
 
-    def __init__(self, auth):
+    def __init__(self, auth=None):
         """ Initialise object """
         self._auth = auth
-        self._tokens = self._auth.get_tokens()
+        self._tokens = self._auth.get_tokens() if self._auth else None
 
     def _mode(self):
         """ Return the mode that should be used for API calls """
@@ -159,9 +159,12 @@ class VtmGo:
         :rtype list[LiveChannel]
         """
         import dateutil.parser
-        response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode(),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+        if self._tokens:
+            response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode(),
+                                     token=self._tokens.jwt_token,
+                                     profile=self._tokens.profile)
+        else:
+            response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode())
         info = json.loads(response.text)
 
         channels = []

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -58,8 +58,8 @@ class VtmGo:
          :rtype: list[Category|Program|Movie]
          """
         response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s' % (self._mode(), storefront),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         result = json.loads(response.text)
 
         items = []
@@ -101,8 +101,8 @@ class VtmGo:
          :rtype: Category
          """
         response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s/detail/%s' % (self._mode(), storefront, category),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         result = json.loads(response.text)
 
         items = []
@@ -118,8 +118,8 @@ class VtmGo:
     def get_swimlane(self, swimlane, content_filter=None, cache=CACHE_ONLY):
         """ Returns the contents of My List """
         response = util.http_get(API_ENDPOINT + '/%s/main/swimlane/%s' % (self._mode(), swimlane),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
 
         # Result can be empty
         if not response.text:
@@ -159,12 +159,9 @@ class VtmGo:
         :rtype list[LiveChannel]
         """
         import dateutil.parser
-        if self._tokens:
-            response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode(),
-                                     token=self._tokens.jwt_token,
-                                     profile=self._tokens.profile)
-        else:
-            response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode())
+        response = util.http_get(API_ENDPOINT + '/%s/live' % self._mode(),
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         info = json.loads(response.text)
 
         channels = []
@@ -199,8 +196,8 @@ class VtmGo:
         :rtype list[Category]
         """
         response = util.http_get(API_ENDPOINT + '/%s/catalog/filters' % self._mode(),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         info = json.loads(response.text)
 
         categories = []
@@ -223,8 +220,8 @@ class VtmGo:
         # Fetch from API
         response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(),
                                  params={'pageSize': 2000, 'filter': quote(category) if category else None},
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         info = json.loads(response.text)
         content = info.get('pagedTeasers', {}).get('content', [])
 
@@ -255,8 +252,8 @@ class VtmGo:
         if movie is None:
             # Fetch from API
             response = util.http_get(API_ENDPOINT + '/%s/movies/%s' % (self._mode(), movie_id),
-                                     token=self._tokens.jwt_token,
-                                     profile=self._tokens.profile)
+                                     token=self._tokens.jwt_token if self._tokens else None,
+                                     profile=self._tokens.profile if self._tokens else None)
             info = json.loads(response.text)
             movie = info.get('movie', {})
             kodiutils.set_cache(['movie', movie_id], movie)
@@ -293,8 +290,8 @@ class VtmGo:
         if program is None:
             # Fetch from API
             response = util.http_get(API_ENDPOINT + '/%s/programs/%s' % (self._mode(), program_id),
-                                     token=self._tokens.jwt_token,
-                                     profile=self._tokens.profile)
+                                     token=self._tokens.jwt_token if self._tokens else None,
+                                     profile=self._tokens.profile if self._tokens else None)
             info = json.loads(response.text)
             program = info.get('program', {})
             kodiutils.set_cache(['program', program_id], program)
@@ -398,8 +395,8 @@ class VtmGo:
         :rtype Episode
         """
         response = util.http_get(API_ENDPOINT + '/%s/play/episode/%s' % (self._mode(), episode_id),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         episode = json.loads(response.text)
 
         # Extract next episode info if available
@@ -453,8 +450,8 @@ class VtmGo:
         # Fetch from API
         response = util.http_get(API_ENDPOINT + '/%s/catalog' % self._mode(),
                                  params={'pageSize': 2000, 'filter': None},
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         info = json.loads(response.text)
 
         items = [item.get('target', {}).get('id') for item in info.get('pagedTeasers', {}).get('content', [])]
@@ -469,8 +466,8 @@ class VtmGo:
         """
         response = util.http_get(API_ENDPOINT + '/%s/search/?query=%s' % (self._mode(),
                                                                           kodiutils.to_unicode(quote(kodiutils.from_unicode(search)))),
-                                 token=self._tokens.jwt_token,
-                                 profile=self._tokens.profile)
+                                 token=self._tokens.jwt_token if self._tokens else None,
+                                 profile=self._tokens.profile if self._tokens else None)
         results = json.loads(response.text)
 
         items = []

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 
 from resources.lib import kodiutils
 from resources.lib.vtmgo import ResolvedStream, util
-from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,14 +20,10 @@ class VtmGoStream:
 
     _API_KEY = 'jL3yNhGpDsaew9CqJrDPq2UzMrlmNVbnadUXVOET'
 
-    def __init__(self):
+    def __init__(self, auth=None):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
-        self._tokens = self._auth.get_tokens()
+        self._auth = auth
+        self._tokens = self._auth.get_tokens() if self._auth else None
 
     def _mode(self):
         """ Return the mode that should be used for API calls """

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14,14 +14,13 @@ import unittest
 
 import pytest
 
-from resources.lib import addon, kodiutils
+from resources.lib import addon
 from resources.lib.service import BackgroundService
 
 routing = addon.routing
 
 
 @unittest.skipIf(sys.platform.startswith("win"), 'Skipping on Windows.')
-@unittest.skipUnless(kodiutils.get_setting('username') and kodiutils.get_setting('password'), 'Skipping since we have no credentials.')
 class TestService(unittest.TestCase):
     """ Tests for the background service """
 


### PR DESCRIPTION
On a clean install, when there are no credentials filled in, and IPTV Manager is querying for information, an exception is raised to indicate that there are no credentials.

We don't need to do this, since we can query the channels and EPG fine without credentials. Credentials will be asked when a channel or VOD is played for the first time.