### PR TITLE
Improve detection of outdated auth tokens

### DIFF
--- a/resources/lib/modules/authentication.py
+++ b/resources/lib/modules/authentication.py
@@ -37,8 +37,8 @@ class Authentication:
             return
 
         except InvalidTokenException:
-            self._auth.delete_cache()
-            kodiutils.redirect(kodiutils.url_for('show_main_menu'))
+            self._auth.logout()
+            kodiutils.redirect(kodiutils.url_for('select_profile'))
             return
 
         except LoginErrorException as exc:


### PR DESCRIPTION
This fixes authentication when 'Always use the current profile' is enabled and fixes https://github.com/add-ons/plugin.video.vtm.go/issues/281
This includes:
- check issued at time of JWT
- check expiration time of JWT