### PR TITLE
Fix play from EPG by datetime

### DIFF
--- a/resources/lib/vtmgo/vtmgoepg.py
+++ b/resources/lib/vtmgo/vtmgoepg.py
@@ -171,7 +171,7 @@ class VtmGoEpg:
 
         # Find a matching broadcast
         for broadcast in epg.broadcasts:
-            if timestamp <= broadcast.time < (broadcast.time + timedelta(seconds=broadcast.duration)):
+            if broadcast.time <= timestamp < (broadcast.time + timedelta(seconds=broadcast.duration)):
                 return broadcast
 
         return None


### PR DESCRIPTION
The loop was wrong and only picked up the program when it started at exactly the specified time.