### PR TITLE
Fix empty movie entries in list after play

### DIFF
--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -211,8 +211,7 @@ class VtmGo:
             response = util.http_get(API_ENDPOINT + '/%s/movies/%s' % (self._mode(), movie_id),
                                      token=self._tokens.access_token if self._tokens else None,
                                      profile=self._tokens.profile if self._tokens else None)
-            info = json.loads(response.text)
-            movie = info.get('movie', {})
+            movie = json.loads(response.text)
             kodiutils.set_cache(['movie', movie_id], movie)
 
         return Movie(
@@ -220,8 +219,9 @@ class VtmGo:
             name=movie.get('name'),
             description=movie.get('description'),
             duration=movie.get('durationSeconds'),
-            thumb=movie.get('teaserImageUrl'),
-            fanart=movie.get('bigPhotoUrl'),
+            thumb=movie.get('landscapeTeaserImageUrl'),
+            # portraitthumb=movie.get('portraitTeaserImageUrl'),
+            fanart=movie.get('backgroundImageUrl'),
             year=movie.get('productionYear'),
             geoblocked=movie.get('blockedFor') == 'GEO',
             remaining=movie.get('remainingDaysAvailable'),


### PR DESCRIPTION
After starting a movie, when returning to the list, the entry is showing empty. This is due to an empty cache entry being created. This PR fixes fetching the information.
I also added info about a portrait image as some of you may be interested.