### PR TITLE
Filter category names

### DIFF
--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -68,7 +68,7 @@ class VtmGo:
             if row.get('rowType') in ['SWIMLANE_DEFAULT', 'SWIMLANE_PORTRAIT', 'SWIMLANE_LANDSCAPE']:
                 items.append(Category(
                     category_id=row.get('id'),
-                    title=row.get('title'),
+                    title=row.get('title').strip(),
                 ))
                 continue
 


### PR DESCRIPTION
It seems the category "Streamz series voor jou" contains a bunch of extra `\t` characters at the end, showing as boxes in the UI. We should strip these.