### PR TITLE
Run tests on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 ]
         include:
           # Kodi Leia on Windows uses a bundled Python 2.7.
           - os: windows-latest
             python-version: 2.7
 
-          # Kodi Matrix on Windows uses a bundled Python 3.8, but we test 3.9 also to be sure.
+          # Kodi Matrix on Windows uses a bundled Python 3.8, but we test 3.9 and 3.10 also to be sure.
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
             python-version: 3.9
+          - os: windows-latest
+            python-version: 3.10
     steps:
       - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10' ]
         include:
           # Kodi Leia on Windows uses a bundled Python 2.7.
           - os: windows-latest
-            python-version: 2.7
+            python-version: '2.7'
 
           # Kodi Matrix on Windows uses a bundled Python 3.8, but we test 3.9 and 3.10 also to be sure.
           - os: windows-latest
-            python-version: 3.8
+            python-version: '3.8'
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.9'
           - os: windows-latest
-            python-version: 3.10
+            python-version: '3.10'
     steps:
       - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
         uses: actions/checkout@v2

--- a/resources/lib/modules/proxy.py
+++ b/resources/lib/modules/proxy.py
@@ -78,7 +78,7 @@ class Proxy(BaseHTTPRequestHandler):
             params = parse_qs(urlparse(self.path).query)
             url = params.get('path')[0]
             _LOGGER.debug('Proxying to %s', url)
-            response = requests.get(url=url)
+            response = requests.get(url=url, timeout=30)
 
             # Return response code
             self.send_response(response.status_code)


### PR DESCRIPTION
* Add Python 3.10 to the list of tested versions.
* Fixed a missing timeout that pylint complained about.