### PR TITLE
Remove VTM Kids channel since they stopped airing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Meer informatie kan je vinden op de [Wiki pagina](https://github.com/add-ons/plu
 ## Features
 De volgende features worden ondersteund:
 
-* Kijk live TV (VTM, VTM 2, VTM 3, VTM 4, VTM Gold, VTM Kids & QMusic)
+* Kijk live TV (VTM, VTM 2, VTM 3, VTM 4, VTM Gold & QMusic)
 * Kijk on-demand content (films en series)
 * Doorblader de VTM GO aanbevelingen en "Mijn lijst"
 * Bekijk en speel rechtstreeks vanaf de TV gids

--- a/resources/lib/modules/__init__.py
+++ b/resources/lib/modules/__init__.py
@@ -84,21 +84,6 @@ CHANNELS = OrderedDict([
         iptv_id='vtmgold.be',
         studio_icon='VTM Gold',
     )),
-    ('vtmkids', dict(
-        label='VTM KIDS',
-        epg='vtm-kids',
-        iptv_preset=13,
-        iptv_id='vtmkids.be',
-        studio_icon='VTM Kids',
-        youtube=[
-            dict(
-                # VTM KIDS: https://www.youtube.com/channel/UCJgZKD2qpa7mY2BtIgpNR2Q
-                label='VTM KIDS',
-                logo='vtmkids',
-                path='plugin://plugin.video.youtube/channel/UCJgZKD2qpa7mY2BtIgpNR2Q/',
-            ),
-        ]
-    )),
     ('qmusic', dict(
         label='QMusic',
         epg='qmusic',

--- a/tests/test_epg.py
+++ b/tests/test_epg.py
@@ -31,7 +31,7 @@ class TestEpg(unittest.TestCase):
 
         import dateutil
 
-        timestamp = datetime.datetime.now(dateutil.tz.tzlocal()).replace(hour=12, minute=0, second=0)
+        timestamp = datetime.datetime.now(dateutil.tz.tzlocal()).replace(hour=13, minute=0, second=0)
         broadcast = self.epg.get_broadcast('vtm', timestamp.isoformat())
         self.assertTrue(broadcast)
 


### PR DESCRIPTION
The dedicated channel VTM Kids stopped airing, so we can remove this from the addon.

See https://www.hln.be/tv/vtm-doekt-vtm-kids-op-en-gaat-samenwerken-met-studio-100-kinderen-kijken-geen-lineaire-tv-meer~a74b4580/