### PR TITLE
Fix recommendations and drop usage of Popcorn V5 API

### DIFF
--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -107,7 +107,7 @@ class VtmGo:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('teasers'):
+        for item in result.get('row', {}).get('teasers'):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                 items.append(self._parse_movie_teaser(item))
 
@@ -129,7 +129,7 @@ class VtmGo:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('teasers'):
+        for item in result.get('teasers', []):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE and content_filter in [None, Movie]:
                 items.append(self._parse_movie_teaser(item, cache=cache))
 

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -18,7 +18,6 @@ _LOGGER = logging.getLogger(__name__)
 class VtmGoStream:
     """ VTM GO Stream API """
 
-    _V5_API_KEY = '3vjmWnsxF7SUTeNCBZlnUQ4Z7GQV8f6miQ514l10'
     _V6_API_KEY = 'r9EOnHOp1pPL5L4FuGzBPSIHwrQnPu5TBfW16y75'
 
     def __init__(self, tokens=None):
@@ -160,34 +159,21 @@ class VtmGoStream:
         """
         url = 'https://videoplayer-service.dpgmedia.net/config/%s/%s' % (strtype, stream_id)
         _LOGGER.debug('Getting video info from %s', url)
-        # Live channels: Fallback to old Popcorn SDK 5 for Kodi 19 and lower, because new livestream format is not supported
-        if kodiutils.kodi_version_major() <= 19 and strtype == 'channels':
-            response = util.http_get(url,
-                                     params={
-                                         'startPosition': '0.0',
-                                         'autoPlay': 'true',
-                                     },
-                                     headers={
-                                         'Accept': 'application/json',
-                                         'x-api-key': self._V5_API_KEY,
-                                         'Popcorn-SDK-Version': '5',
-                                     })
-        else:
-            response = util.http_post(url,
-                                      params={
-                                          'startPosition': '0.0',
-                                          'autoPlay': 'true',
-                                      },
-                                      data={
-                                          'deviceType': 'android-tv',
-                                          'zone': 'vtmgo',
-                                      },
-                                      headers={
-                                          'Accept': 'application/json',
-                                          'x-api-key': self._V6_API_KEY,
-                                          'Popcorn-SDK-Version': '6',
-                                          'Authorization': 'Bearer ' + player_token,
-                                      })
+        response = util.http_post(url,
+                                  params={
+                                      'startPosition': '0.0',
+                                      'autoPlay': 'true',
+                                  },
+                                  data={
+                                      'deviceType': 'android-tv',
+                                      'zone': 'vtmgo',
+                                  },
+                                  headers={
+                                      'Accept': 'application/json',
+                                      'x-api-key': self._V6_API_KEY,
+                                      'Popcorn-SDK-Version': '6',
+                                      'Authorization': 'Bearer ' + player_token,
+                                  })
 
         info = json.loads(response.text)
         return info


### PR DESCRIPTION
The Popcorn V5 api isn't working anymore, so the workaround for Kodi Leia has to be removed for the tests to succeed.