### PR TITLE
Update to API 17

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -80,6 +80,11 @@ def show_tvguide_detail(channel=None, date=None):
     from resources.lib.modules.tvguide import TvGuide
     TvGuide().show_tvguide_detail(channel, date)
 
+@routing.route('/catalog/detail/<item>')
+def show_detail(item):
+    """ Show a program from the catalog """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_detail(item)
 
 @routing.route('/catalog/program/<program>')
 def show_catalog_program(program):

--- a/resources/lib/modules/menu.py
+++ b/resources/lib/modules/menu.py
@@ -7,7 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
-from resources.lib.vtmgo import STOREFRONT_KIDS, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SHORTIES, Episode, Movie, Program
+from resources.lib.vtmgo import STOREFRONT_KIDS, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SHORTIES, Episode, Movie, Program, Teaser
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class Menu:
             plot += '\n'
 
         # Add remaining
-        if hasattr(obj, 'remaining') and obj.remaining is not None:
+        if hasattr(obj, 'remaining') and obj.remaining:
             if obj.remaining == 0:
                 plot += '» ' + kodiutils.localize(30208) + "\n"  # Available until midnight
             elif obj.remaining == 1:
@@ -166,7 +166,7 @@ class Menu:
             plot += kodiutils.localize(30207)  # Geo-blocked
             plot += '\n'
 
-        if hasattr(obj, 'description'):
+        if hasattr(obj, 'description') and obj.description:
             plot += obj.description
             plot += '\n\n'
 
@@ -188,8 +188,8 @@ class Menu:
         info_dict = {
             'title': item.name,
             'plot': cls.format_plot(item),
-            'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
-            'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else kodiutils.localize(30216),  # All ages
+            # 'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
+            # 'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else kodiutils.localize(30216),  # All ages
         }
         prop_dict = {}
 
@@ -316,5 +316,38 @@ class Menu:
                 context_menu=context_menu,
                 is_playable=True,
             )
+
+        #
+        # Teaser
+        #
+        if isinstance(item, Teaser):
+            # if item.my_list:
+            #     context_menu = [(
+            #         kodiutils.localize(30101),  # Remove from My List
+            #         'Container.Update(%s)' %
+            #         kodiutils.url_for('mylist_del', content_id=item.program_id)
+            #     )]
+            # else:
+            #     context_menu = [(
+            #         kodiutils.localize(30100),  # Add to My List
+            #         'Container.Update(%s)' %
+            #         kodiutils.url_for('mylist_add', content_id=item.program_id)
+            #     )]
+
+            # info_dict.update({
+            #     'mediatype': 'tvshow',
+            #     'year': item.year,
+            #     'season': len(item.seasons),
+            # })
+
+            return kodiutils.TitleItem(
+                title=info_dict['title'],
+                path=kodiutils.url_for('show_detail', item=item.detail_id),
+                art_dict=art_dict,
+                info_dict=info_dict,
+                prop_dict=prop_dict,
+                # context_menu=context_menu,
+            )
+
 
         raise Exception('Unknown video_type')

--- a/resources/lib/vtmgo/__init__.py
+++ b/resources/lib/vtmgo/__init__.py
@@ -96,6 +96,28 @@ class Category:
     def __repr__(self):
         return "%r" % self.__dict__
 
+class Teaser:
+    """ Defines a Teaser """
+
+    def __init__(self, detail_id=None, name=None, description=None, poster=None, thumb=None, fanart=None):
+        """
+        :type detail_id: str
+        :type name: str
+        :type description: str
+        :type poster: str
+        :type thumb: str
+        :type fanart: str
+        """
+        self.detail_id = detail_id
+        self.name = name
+        self.description = description
+        self.poster = poster
+        self.thumb = thumb
+        self.fanart = fanart
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
 
 class Movie:
     """ Defines a Movie """

--- a/resources/lib/vtmgo/util.py
+++ b/resources/lib/vtmgo/util.py
@@ -17,8 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTM_GO/15.231023 (be.vmma.vtm.zenderapp; build:18041; Android 23) okhttp/4.11.0',
-    'x-app-version': '15',
+    'User-Agent': 'VTM_GO/17.240626 (be.vmma.vtm.zenderapp; build:19069; Android 28) okhttp/4.12.0',
+    'x-app-version': '17',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '28',

--- a/resources/lib/vtmgo/vtmgostream.py
+++ b/resources/lib/vtmgo/vtmgostream.py
@@ -157,7 +157,7 @@ class VtmGoStream:
         :param str player_token:
         :rtype: dict
         """
-        url = 'https://videoplayer-service.dpgmedia.net/config/%s/%s' % (strtype, stream_id)
+        url = 'https://videoplayer-service.dpgmedia.net/play-config/%s' % stream_id
         _LOGGER.debug('Getting video info from %s', url)
         response = util.http_post(url,
                                   params={
@@ -171,7 +171,7 @@ class VtmGoStream:
                                   headers={
                                       'Accept': 'application/json',
                                       'x-api-key': self._V6_API_KEY,
-                                      'Popcorn-SDK-Version': '6',
+                                      'Popcorn-SDK-Version': '7',
                                       'Authorization': 'Bearer ' + player_token,
                                   })
 


### PR DESCRIPTION
Still WIP

It seems it's not possible to differentiate between a Program or a Movie by looking at a teaser, so we construct a generic Teaser object. This is converted to a TitleItem that will go to show_details when selected in the UI. This uses the /detail/ API (the one that Program used in the past).

When we see that `selectedSeason` contains info, we assume it's a Program, else we assume it's a Movie.

This unfortunately causes a list with one TitleItem to be visible that will actually start playing that movie.
